### PR TITLE
Suppress report issue on activation failure

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,6 +74,7 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         if (dockerExtension && (dockerExtension.packageJSON as { version: string }).version) {
             const dockerExtensionVersion = semver.coerce(dockerExtension.packageJSON.version);
             if (dockerExtensionVersion && semver.lt(dockerExtensionVersion, '2.0.0')) {
+                activateContext.errorHandling.suppressReportIssue = true;
                 throw new Error(vscode.l10n.t('An unsupported version of the Docker extension is installed. Please update the Docker extension to version 2.0.0 or later. The Container Tools extension will not activate.'));
             }
         }


### PR DESCRIPTION
Noticed while investigating #23. We shouldn't leave the Report Issue button there or it's going to get (ab)used.