### PR TITLE
Add a command to choose container runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
                     "group": "navigation@1"
                 },
                 {
+                    "command": "vscode-containers.chooseContainerRuntime",
+                    "when": "view == vscode-containers.views.containers",
+                    "group": "navigation@7"
+                },
+                {
                     "command": "vscode-containers.containers.configureExplorer",
                     "when": "view == vscode-containers.views.containers",
                     "group": "navigation@8"
@@ -2770,6 +2775,12 @@
                 "command": "vscode-containers.help.openWalkthrough",
                 "title": "%vscode-containers.commands.help.openWalkthrough%",
                 "category": "%vscode-containers.commands.category.containersGeneric%"
+            },
+            {
+                "command": "vscode-containers.chooseContainerRuntime",
+                "title": "%vscode-containers.commands.chooseContainerRuntime%",
+                "category": "%vscode-containers.commands.category.containersGeneric%",
+                "icon": "$(tools)"
             },
             {
                 "command": "vscode-containers.contexts.use",

--- a/package.nls.json
+++ b/package.nls.json
@@ -236,6 +236,7 @@
     "vscode-containers.commands.help": "Container Help",
     "vscode-containers.commands.help.reportIssue": "Report Issue",
     "vscode-containers.commands.help.openWalkthrough": "Open Container Tools Extension Walkthrough",
+    "vscode-containers.commands.chooseContainerRuntime": "Choose container runtime...",
     "vscode-containers.commands.images.build": "Build Image...",
     "vscode-containers.commands.images.configureExplorer": "Configure Explorer...",
     "vscode-containers.commands.images.inspect": "Inspect",

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -22,7 +22,6 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
             label: client.displayName,
             data: client,
             description: client.description,
-            detail: "foo"
         };
     });
 

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -14,11 +14,15 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
         new PodmanClient(),
     ];
 
+    const configuration = vscode.workspace.getConfiguration(configPrefix);
+    const oldValue = configuration.get<string | undefined>('containerClient');
+
     const containerRuntimeChoices: IAzureQuickPickItem<IContainersClient>[] = clientOptions.map((client) => {
         return {
             label: client.displayName,
             data: client,
             description: client.description,
+            detail: "foo"
         };
     });
 
@@ -29,9 +33,11 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
 
     context.telemetry.properties.selectedRuntime = selectedClient.data.displayName;
 
-    const configuration = vscode.workspace.getConfiguration(configPrefix);
-    await configuration.update('containerClient', selectedClient.data.id);
-
+    if (oldValue === selectedClient.data.id) {
+        return;
+    } else {
+        await configuration.update('containerClient', selectedClient.data.id);
+    }
 
     const reload: vscode.MessageItem = {
         title: vscode.l10n.t('Reload Now'),

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { DockerClient, IContainersClient, PodmanClient } from '@microsoft/vscode-container-client';
+import * as vscode from 'vscode';
+import { configPrefix } from '../constants';
+
+export async function chooseContainerRuntime(context: IActionContext): Promise<void> {
+    const clientOptions = [
+        new DockerClient(),
+        new PodmanClient(),
+    ];
+
+    const containerRuntimeChoices: IAzureQuickPickItem<IContainersClient>[] = clientOptions.map((client) => {
+        return {
+            label: client.displayName,
+            data: client,
+            description: client.description,
+        };
+    });
+
+    const selectedClient = await context.ui.showQuickPick(containerRuntimeChoices, {
+        placeHolder: 'Choose a container runtime',
+        suppressPersistence: true,
+    });
+
+    context.telemetry.properties.selectedRuntime = selectedClient.data.displayName;
+
+    const configuration = vscode.workspace.getConfiguration(configPrefix);
+    await configuration.update('containerClient', selectedClient.data.id);
+
+
+    const reload: vscode.MessageItem = {
+        title: vscode.l10n.t('Reload Now'),
+    };
+    const later: vscode.MessageItem = {
+        title: vscode.l10n.t('Later'),
+    };
+
+    const message = vscode.l10n.t('The container runtime has been changed to {0}. A reload is required for the setting to take effect. Do you want to reload now? Please save your work before proceeding.', selectedClient.data.displayName);
+
+    const reloadChoice = await context.ui.showWarningMessage(message, reload, later);
+
+    if (reloadChoice === reload) {
+        await vscode.commands.executeCommand('workbench.action.reloadWindow');
+    }
+}

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -35,7 +35,7 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
     if (oldValue === selectedClient.data.id) {
         return;
     } else {
-        await configuration.update('containerClient', selectedClient.data.id);
+        await configuration.update('containerClient', selectedClient.data.id, vscode.ConfigurationTarget.Global);
     }
 
     const reload: vscode.MessageItem = {

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -45,7 +45,7 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
         title: vscode.l10n.t('Later'),
     };
 
-    const message = vscode.l10n.t('The container runtime has been changed to {0}. A reload is required for the setting to take effect. Do you want to reload now? Please save your work before proceeding.', selectedClient.data.displayName);
+    const message = vscode.l10n.t('The container runtime has been changed to {0}. A reload is required for the updated container runtime to take effect. Do you want to reload now? Please save your work before proceeding.', selectedClient.data.displayName);
 
     const reloadChoice = await context.ui.showWarningMessage(message, reload, later);
 

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -9,6 +9,7 @@ import { ext } from "../extensionVariables";
 import { scaffold } from "../scaffolding/scaffold";
 import { scaffoldCompose } from "../scaffolding/scaffoldCompose";
 import { scaffoldDebugConfig } from "../scaffolding/scaffoldDebugConfig";
+import { chooseContainerRuntime } from "./chooseContainerRuntime";
 import { composeDown, composeRestart, composeUp, composeUpSubset } from "./compose/compose";
 import { attachShellContainer } from "./containers/attachShellContainer";
 import { browseContainer } from "./containers/browseContainer";
@@ -209,6 +210,7 @@ export function registerCommands(): void {
     registerCommand('vscode-containers.help', help);
     registerCommand('vscode-containers.help.openWalkthrough', () => commands.executeCommand('workbench.action.openWalkthrough', 'ms-azuretools.vscode-containers#containersStart'));
     registerCommand('vscode-containers.help.reportIssue', reportIssue);
+    registerCommand('vscode-containers.chooseContainerRuntime', chooseContainerRuntime);
 
     registerCommand('vscode-containers.activateContainerRuntimeProviders', (context: IActionContext) => {
         // Do nothing, but container runtime provider extensions can use this command as an activation event

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
             const dockerExtensionVersion = semver.coerce(dockerExtension.packageJSON.version);
             if (dockerExtensionVersion && semver.lt(dockerExtensionVersion, '2.0.0')) {
                 activateContext.errorHandling.suppressReportIssue = true;
-                throw new Error(vscode.l10n.t('An unsupported version of the Docker extension is installed. Please update the Docker extension to version 2.0.0 or later. The Container Tools extension will not activate.'));
+                throw new Error(vscode.l10n.t('The Container Tools extension is incompatible with the Docker extension and cannot activate. Uninstall Docker and reload to use Container Tools.'));
             }
         }
 

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -292,11 +292,11 @@ export abstract class LocalRootTreeItemBase<TItem extends AnyContainerObject, TP
                 new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} running?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
                 new GenericTreeItem(this, { label: l10n.t('  Error: {0}', parsedError.message), contextValue: 'connectionError' }),
                 new OpenUrlTreeItem(this, l10n.t('Additional Troubleshooting...'), 'https://aka.ms/AA37qt2'),
-                new GenericTreeItem(this, { label: l10n.t('Choose another container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
+                new GenericTreeItem(this, { label: l10n.t('Configure container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
             ]
             : [
                 new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} installed?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
-                new GenericTreeItem(this, { label: l10n.t('Choose another container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
+                new GenericTreeItem(this, { label: l10n.t('Configure container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
             ];
 
         const remoteInfo: IVSCodeRemoteInfo = getVSCodeRemoteInfo(context);

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -291,9 +291,13 @@ export abstract class LocalRootTreeItemBase<TItem extends AnyContainerObject, TP
             ? [
                 new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} running?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
                 new GenericTreeItem(this, { label: l10n.t('  Error: {0}', parsedError.message), contextValue: 'connectionError' }),
-                new OpenUrlTreeItem(this, l10n.t('Additional Troubleshooting...'), 'https://aka.ms/AA37qt2')
+                new OpenUrlTreeItem(this, l10n.t('Additional Troubleshooting...'), 'https://aka.ms/AA37qt2'),
+                new GenericTreeItem(this, { label: l10n.t('Choose another container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
             ]
-            : [new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} installed?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) })];
+            : [
+                new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} installed?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
+                new GenericTreeItem(this, { label: l10n.t('Choose another container runtime...'), commandId: 'vscode-containers.chooseContainerRuntime', contextValue: 'connectionError', iconPath: new ThemeIcon('tools') })
+            ];
 
         const remoteInfo: IVSCodeRemoteInfo = getVSCodeRemoteInfo(context);
         if (remoteInfo.extensionKind === DockerExtensionKind.workspace && remoteInfo.remoteKind === RemoteKind.devContainer) {

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -102,7 +102,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
 
     protected getTreeItemForEmptyList(): AzExtTreeItem[] {
         if (this.newContainerUser) {
-            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, l10n.t('Tutorial: Get started with Docker'), 'https://aka.ms/getstartedwithdocker');
+            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, l10n.t('Tutorial: Get started with containers'), 'https://aka.ms/getstartedwithdocker');
             dockerTutorialTreeItem.iconPath = new ThemeIcon('link-external');
             return [dockerTutorialTreeItem];
         }


### PR DESCRIPTION
Fixes #56, fixes #57, fixes #62

Shows up in Containers sash (and command palette):
![image](https://github.com/user-attachments/assets/ed95f5ee-b473-42f0-b640-ebe6f79ff5da)

Prompt:
![image](https://github.com/user-attachments/assets/02b9102a-e714-42cf-9481-71d418524387)

Followup reload prompt:
![image](https://github.com/user-attachments/assets/a35cf6f3-2d76-472d-b2c4-f0ccedccfbea)

Message if your chosen runtime is not installed:
![image](https://github.com/user-attachments/assets/1b7be680-0bb3-4144-946d-62a9f90e75de)

Message if your chosen runtime is installed but not running:
![image](https://github.com/user-attachments/assets/b7936d4f-3124-4394-8d5a-06be06ccec48)