### PR TITLE
Adding config option to run docker commands in WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2328,6 +2328,18 @@
                         "Docker Compose",
                         "Podman Compose"
                     ]
+                },
+                "containers.executeInWSL": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%vscode-containers.config.containers.executeInWSL%",
+                    "scope": "machine-overridable"
+                },
+                "containers.executeInWSLDistro": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "%vscode-containers.config.containers.executeInWSLDistro%",
+                    "scope": "machine-overridable"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -204,6 +204,8 @@
     "vscode-containers.config.containers.enableComposeLanguageService": "Whether or not to enable the Compose Language Service. Changing requires a restart to take effect.",
     "vscode-containers.config.containers.containerClient": "Which container client to use. If not specified, Docker will be used. Changing requires a restart to take effect.",
     "vscode-containers.config.containers.orchestratorClient": "Which container orchestrator client to use. If not specified, Docker Compose will be used. Changing requires a restart to take effect.",
+    "vscode-containers.config.containers.executeInWSL": "Controls whether container and compose actions should be executed in WSL. This setting has no effect on other platforms than Windows.",
+    "vscode-containers.config.containers.executeInWSLDistro": "WSL distribution to use when executing container actions. The default is to use the default WSL distro (see `wsl -l`). This setting has no effect when `#vscode-containers.config.containers.executeInWSL#` is not enabled or on other platforms than Windows.",
     "vscode-containers.config.deprecated": "This setting has been deprecated and will be removed in a future release.",
     "vscode-containers.commands.compose.down": "Compose Down",
     "vscode-containers.commands.compose.restart": "Compose Restart",

--- a/src/commands/compose/getComposeSubsetList.ts
+++ b/src/commands/compose/getComposeSubsetList.ts
@@ -7,7 +7,6 @@ import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-uti
 import { CommandLineArgs, PromiseCommandResponse, quoted, VoidCommandResponse } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { runWithDefaults } from '../../runtimes/runners/runWithDefaults';
 import { execAsync } from '../../utils/execAsync';
 
 // Matches an `up` or `down` and everything after it--so that it can be replaced with `config --services`, to get a service list using all of the files originally part of the compose command
@@ -221,7 +220,7 @@ async function getDefaultCommandServiceSubsets(workspaceFolder: vscode.Workspace
     configCommand.args.push('config', `--${type}`);
 
     try {
-        return await runWithDefaults(() => configCommand, { cwd: workspaceFolder.uri?.fsPath });
+        return await ext.runWithDefaults(() => configCommand, { cwd: workspaceFolder.uri?.fsPath });
     } catch (err) {
         // Profiles is not yet widely supported, so those errors will be eaten--otherwise, rethrow
         if (type === 'profiles') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { AutoConfigurableDockerComposeClient } from './runtimes/clients/AutoConf
 import { AutoConfigurablePodmanClient } from './runtimes/clients/AutoConfigurablePodmanClient';
 import { AutoConfigurablePodmanComposeClient } from './runtimes/clients/AutoConfigurablePodmanComposeClient';
 import { ContainerRuntimeManager } from './runtimes/ContainerRuntimeManager';
+import { ExecutionEnvironmentManager } from './runtimes/ExecutionEnvironmentManager';
 import { ContainerFilesProvider } from './runtimes/files/ContainerFilesProvider';
 import { OrchestratorRuntimeManager } from './runtimes/OrchestratorRuntimeManager';
 import { registerTaskProviders } from './tasks/TaskHelper';
@@ -109,9 +110,11 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
 
         // Set up runtime managers
         ctx.subscriptions.push(
+            ext.executionManger = new ExecutionEnvironmentManager(),
             ext.runtimeManager = new ContainerRuntimeManager(),
             ext.orchestratorManager = new OrchestratorRuntimeManager()
         );
+        ext.executionManger.registerConfigListener();
 
         // Set up Container clients
         registerContainerClients();

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -7,6 +7,7 @@ import { AzExtTreeDataProvider, AzExtTreeItem, IExperimentationServiceAdapter } 
 import { DockerHubRegistryDataProvider, GenericRegistryV2DataProvider, GitHubRegistryDataProvider } from '@microsoft/vscode-docker-registries';
 import { ExtensionContext, StatusBarItem, TreeView } from 'vscode';
 import { ContainerRuntimeManager } from './runtimes/ContainerRuntimeManager';
+import { ExecutionEnvironmentManager } from './runtimes/ExecutionEnvironmentManager';
 import { OrchestratorRuntimeManager } from './runtimes/OrchestratorRuntimeManager';
 import { runWithDefaults as runWithDefaultsImpl, streamWithDefaults as streamWithDefaultsImpl } from './runtimes/runners/runWithDefaults';
 import { IActivityMeasurementService } from './telemetry/ActivityMeasurementService';
@@ -65,6 +66,7 @@ export namespace ext {
     // Container runtime related items
     export let runtimeManager: ContainerRuntimeManager;
     export let orchestratorManager: OrchestratorRuntimeManager;
+    export let executionManger: ExecutionEnvironmentManager;
     export const runWithDefaults = runWithDefaultsImpl;
     export const streamWithDefaults = streamWithDefaultsImpl;
 

--- a/src/runtimes/ExecutionEnvironmentManager.ts
+++ b/src/runtimes/ExecutionEnvironmentManager.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, registerEvent } from '@microsoft/vscode-azext-utils';
+import { CommandResponseBase, composeArgs, withArg, withNamedArg } from '@microsoft/vscode-container-client';
+import * as vscode from 'vscode';
+import { configPrefix } from '../constants';
+import { ext } from '../extensionVariables';
+import { isWindows } from '../utils/osUtils';
+
+export class ExecutionEnvironmentManager implements vscode.Disposable {
+    #useWSL: boolean;
+    public get useWSL(): boolean {
+        return this.#useWSL;
+    }
+    public set useWSL(value: boolean) {
+        this.#useWSL = value;
+    }
+
+    #wslDistro: string | null;
+    public get wslDistro(): string | null {
+        return this.#wslDistro;
+    }
+    public set wslDistro(value: string | null) {
+        this.#wslDistro = value;
+    }
+
+    public constructor() {
+        this.reconfigure();
+    }
+    public dispose(): void {
+    }
+
+    public reconfigure(): void {
+        const config = vscode.workspace.getConfiguration(configPrefix);
+        this.#useWSL = config.get<boolean | undefined>('executeInWSL') || false;
+        this.#wslDistro = config.get<string | undefined>('executeInWSLDistro') || null;
+
+        ext.outputChannel.debug(`${configPrefix}.executeInWSL: ${this.useWSL}`);
+        ext.outputChannel.debug(`${configPrefix}.executeInWSLDistro: ${this.wslDistro}`);
+    }
+
+    public registerConfigListener(): void {
+        // Register an event to watch for changes to config, reconfigure if needed
+        registerEvent('vscode-containers.command.changed', vscode.workspace.onDidChangeConfiguration, (actionContext: IActionContext, e: vscode.ConfigurationChangeEvent) => {
+            actionContext.telemetry.suppressAll = true;
+            actionContext.errorHandling.suppressDisplay = true;
+
+            if (e.affectsConfiguration(`${configPrefix}.executeInWSL`) || e.affectsConfiguration(`${configPrefix}.executeInWSLDistro`)) {
+                this.reconfigure();
+            }
+        });
+    }
+
+    public adjustExecutionArguments(commandResponse: CommandResponseBase, { shouldQuote }: { shouldQuote?: boolean } = {}): CommandResponseBase {
+        if (!this.useWSL || !isWindows()) {
+            return commandResponse;
+        }
+        const command = 'wsl.exe';
+        const args = composeArgs(
+            withNamedArg('-d', this.wslDistro, typeof shouldQuote === "boolean" ? { shouldQuote } : {}),
+            withArg('--'),
+            withArg(commandResponse.command),
+            withArg(...commandResponse.args)
+        )();
+
+        return { command, args };
+
+    }
+}

--- a/src/runtimes/runners/TaskCommandRunnerFactory.ts
+++ b/src/runtimes/runners/TaskCommandRunnerFactory.ts
@@ -6,6 +6,7 @@
 import { CommandLineArgs, CommandNotSupportedError, CommandRunner, ICommandRunnerFactory, Like, normalizeCommandResponseLike, PromiseCommandResponse, StreamingCommandRunner, VoidCommandResponse } from '@microsoft/vscode-container-client';
 import * as os from 'os';
 import * as vscode from 'vscode';
+import { ext } from '../../extensionVariables';
 
 interface TaskCommandRunnerOptions {
     taskName: string;
@@ -23,7 +24,7 @@ export class TaskCommandRunnerFactory implements ICommandRunnerFactory {
 
     public getCommandRunner(): CommandRunner {
         return async <T>(commandResponseLike: Like<PromiseCommandResponse<T> | VoidCommandResponse>) => {
-            const commandResponse = await normalizeCommandResponseLike(commandResponseLike);
+            const commandResponse = ext.executionManger.adjustExecutionArguments(await normalizeCommandResponseLike(commandResponseLike));
             await executeAsTask(this.options, commandResponse.command, commandResponse.args);
             return undefined!;
         };

--- a/src/runtimes/runners/runWithDefaults.ts
+++ b/src/runtimes/runners/runWithDefaults.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AccumulatorStream, ClientIdentity, GeneratorCommandResponse, IContainersClient, isChildProcessError, Like, normalizeCommandResponseLike, NoShell, PromiseCommandResponse, ShellStreamCommandRunnerFactory, ShellStreamCommandRunnerOptions, VoidCommandResponse } from '@microsoft/vscode-container-client';
+import { AccumulatorStream, ClientIdentity, CommandLineArgs, CommandResponseBase, GeneratorCommandResponse, IContainersClient, isChildProcessError, Like, normalizeCommandResponseLike, NoShell, PromiseCommandResponse, ShellStreamCommandRunnerFactory, ShellStreamCommandRunnerOptions, VoidCommandResponse } from '@microsoft/vscode-container-client';
 import * as stream from 'stream';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
@@ -147,6 +147,11 @@ class DefaultEnvStreamCommandRunnerFactory<TOptions extends DefaultEnvStreamComm
         });
 
         this.errAccumulator = errAccumulator;
+    }
+
+    protected override getCommandAndArgs(commandResponse: CommandResponseBase): { command: string; args: CommandLineArgs; } {
+        // This needs to remain unquoted as it's being passed to child_process.spawn
+        return ext.executionManger.adjustExecutionArguments(super.getCommandAndArgs(commandResponse), {shouldQuote: false});
     }
 
     public dispose(): void {


### PR DESCRIPTION
This adds a couple new configuration items that let Container Tools run the Docker commands in a WSL container. There's probably some amount of improvement that can be done to autodetect whether that should be enabled rather than requiring the user to find the config option, but I figure that can be future work.

Also, I'm fully expecting this will come second in line behind #165, whenever that lands, and that's fine; I might as well get the concept out there now, even if I have to refactor it later.