### PR TITLE
Properly handle ACRs that are visible via multiple accounts

### DIFF
--- a/src/commands/registries/azure/openInAzurePortal.ts
+++ b/src/commands/registries/azure/openInAzurePortal.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, createSubscriptionContext } from '@microsoft/vscode-azext-utils';
+import { isRepository } from '@microsoft/vscode-docker-registries';
 import { ext } from '../../../extensionVariables';
 import { AzureRegistry, AzureRepository, AzureSubscriptionRegistryItem, isAzureRegistry, isAzureSubscriptionRegistryItem } from '../../../tree/registries/Azure/AzureRegistryDataProvider';
 import { UnifiedRegistryItem } from '../../../tree/registries/UnifiedRegistryTreeDataProvider';
@@ -26,9 +27,9 @@ export async function openInAzurePortal(context: IActionContext, node?: UnifiedR
         await azExtAzureUtils.openInPortal(subscriptionContext, `/subscriptions/${subscriptionContext.subscriptionId}`);
     } else if (isAzureRegistry(azureRegistryItem)) {
         subscriptionContext = createSubscriptionContext(azureRegistryItem.parent.subscription);
-        await azExtAzureUtils.openInPortal(subscriptionContext, azureRegistryItem.id);
-    } else {
+        await azExtAzureUtils.openInPortal(subscriptionContext, azureRegistryItem.registryProperties.id);
+    } else if (isRepository(azureRegistryItem)) {
         subscriptionContext = createSubscriptionContext(azureRegistryItem.parent.parent.subscription);
-        await azExtAzureUtils.openInPortal(subscriptionContext, `${azureRegistryItem.parent.id}/repository`);
+        await azExtAzureUtils.openInPortal(subscriptionContext, `${azureRegistryItem.parent.registryProperties.id}/repository`);
     }
 }

--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -69,9 +69,12 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
             this.sendSubscriptionTelemetryIfNeeded();
 
             return subscriptions.map(sub => {
+                const isSubFromMultipleAccounts = subscriptions.some(s => s.subscriptionId === sub.subscriptionId && s.account.id !== sub.account.id);
+
                 return {
                     parent: element,
                     label: sub.name,
+                    description: isSubFromMultipleAccounts ? sub.account.label : undefined,
                     type: 'azuresubscription',
                     subscription: sub,
                     additionalContextValues: ['azuresubscription'],
@@ -126,7 +129,7 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
                 iconPath: vscode.Uri.joinPath(this.extensionContext.extensionUri, 'resources', 'azureRegistry.svg'),
                 subscription: subscriptionItem.subscription,
                 additionalContextValues: ['azureContainerRegistry'],
-                id: registry.id!,
+                id: `${subscriptionItem.subscription.account.id}/${registry.id!}`,
                 registryProperties: registry
             };
         });
@@ -136,6 +139,7 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
         if (isAzureSubscriptionRegistryItem(element)) {
             return Promise.resolve({
                 label: element.label,
+                description: element.description,
                 collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
                 contextValue: getContextValue(element),
                 iconPath: element.iconPath,


### PR DESCRIPTION
Current bug: If an ACR is visible via multiple accounts, we will get a duplicate tree ID error.

Fix: Instead of just Azure Resource ID as the tree ID, use accountID/resourceID. Also, need to update `openInAzurePortal` to use the resource ID when opening, instead of the tree ID.

Additionally, when the same subscription appears to multiple accounts, visually dedupe by adding the account label as the node description.