### PR TITLE
Tag most of our settings as advanced

### DIFF
--- a/package.json
+++ b/package.json
@@ -1663,7 +1663,10 @@
                         }
                     ],
                     "default": "${containerCommand} build --pull --rm -f \"${dockerfile}\" -t ${tag} \"${context}\"",
-                    "description": "%vscode-containers.config.template.build.description%"
+                    "description": "%vscode-containers.config.template.build.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.run": {
                     "oneOf": [
@@ -1695,7 +1698,10 @@
                         }
                     ],
                     "default": "${containerCommand} run --rm -d ${exposedPorts} ${tag}",
-                    "description": "%vscode-containers.config.template.run.description%"
+                    "description": "%vscode-containers.config.template.run.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.runInteractive": {
                     "oneOf": [
@@ -1727,7 +1733,10 @@
                         }
                     ],
                     "default": "${containerCommand} run --rm -it ${exposedPorts} ${tag}",
-                    "description": "%vscode-containers.config.template.runInteractive.description%"
+                    "description": "%vscode-containers.config.template.runInteractive.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.attach": {
                     "oneOf": [
@@ -1759,7 +1768,10 @@
                         }
                     ],
                     "default": "${containerCommand} exec -it ${containerId} ${shellCommand}",
-                    "description": "%vscode-containers.config.template.attach.description%"
+                    "description": "%vscode-containers.config.template.attach.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.logs": {
                     "oneOf": [
@@ -1791,7 +1803,10 @@
                         }
                     ],
                     "default": "${containerCommand} logs --tail 1000 -f ${containerId}",
-                    "description": "%vscode-containers.config.template.logs.description%"
+                    "description": "%vscode-containers.config.template.logs.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.composeUp": {
                     "oneOf": [
@@ -1828,7 +1843,10 @@
                             "template": "${composeCommand} ${configurationFile} up ${detached} ${build}"
                         }
                     ],
-                    "description": "%vscode-containers.config.template.composeUp.description%"
+                    "description": "%vscode-containers.config.template.composeUp.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.composeUpSubset": {
                     "oneOf": [
@@ -1865,7 +1883,10 @@
                             "template": "${composeCommand} ${profileList} ${configurationFile} up ${detached} ${build} ${serviceList}"
                         }
                     ],
-                    "description": "%vscode-containers.config.template.composeUpSubset.description%"
+                    "description": "%vscode-containers.config.template.composeUpSubset.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.composeDown": {
                     "oneOf": [
@@ -1902,7 +1923,10 @@
                             "template": "${composeCommand} ${configurationFile} down"
                         }
                     ],
-                    "description": "%vscode-containers.config.template.composeDown.description%"
+                    "description": "%vscode-containers.config.template.composeDown.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.commands.composeDownSubset": {
                     "oneOf": [
@@ -1939,7 +1963,10 @@
                             "template": "${composeCommand} ${profileList} ${configurationFile} down ${serviceList}"
                         }
                     ],
-                    "description": "%vscode-containers.config.template.composeDownSubset.description%"
+                    "description": "%vscode-containers.config.template.composeDownSubset.description%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.containers.groupBy": {
                     "type": "string",
@@ -1965,11 +1992,17 @@
                         "Status",
                         "Tag",
                         "Label"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.containers.groupByLabel": {
                     "type": "string",
-                    "description": "%vscode-containers.config.containers.containers.groupByLabel%"
+                    "description": "%vscode-containers.config.containers.containers.groupByLabel%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.containers.description": {
                     "type": "array",
@@ -1999,7 +2032,10 @@
                             "Status",
                             "Tag"
                         ]
-                    }
+                    },
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.containers.label": {
                     "type": "string",
@@ -2023,6 +2059,9 @@
                         "State",
                         "Status",
                         "Tag"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.containers.sortBy": {
@@ -2032,6 +2071,9 @@
                     "enum": [
                         "CreatedTime",
                         "Label"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.contexts.description": {
@@ -2047,7 +2089,10 @@
                             "Description",
                             "DockerEndpoint"
                         ]
-                    }
+                    },
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.contexts.label": {
                     "type": "string",
@@ -2057,6 +2102,9 @@
                         "Name",
                         "Description",
                         "DockerEndpoint"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.contexts.showInStatusBar": {
@@ -2080,6 +2128,9 @@
                         "RepositoryNameShort",
                         "RepositoryNameAndTag",
                         "Tag"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.images.description": {
@@ -2103,7 +2154,10 @@
                             "Tag",
                             "Size"
                         ]
-                    }
+                    },
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.images.label": {
                     "type": "string",
@@ -2121,6 +2175,9 @@
                         "RepositoryNameAndTag",
                         "Tag",
                         "Size"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.images.sortBy": {
@@ -2131,6 +2188,9 @@
                         "CreatedTime",
                         "Label",
                         "Size"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.images.checkForOutdatedImages": {
@@ -2148,6 +2208,9 @@
                         "NetworkId",
                         "NetworkName",
                         "None"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.networks.description": {
@@ -2165,7 +2228,10 @@
                             "NetworkId",
                             "NetworkName"
                         ]
-                    }
+                    },
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.networks.showBuiltInNetworks": {
                     "type": "boolean",
@@ -2181,6 +2247,9 @@
                         "NetworkDriver",
                         "NetworkId",
                         "NetworkName"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.networks.sortBy": {
@@ -2190,6 +2259,9 @@
                     "enum": [
                         "CreatedTime",
                         "Label"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.volumes.groupBy": {
@@ -2200,6 +2272,9 @@
                         "CreatedTime",
                         "VolumeName",
                         "None"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.volumes.description": {
@@ -2214,7 +2289,10 @@
                             "CreatedTime",
                             "VolumeName"
                         ]
-                    }
+                    },
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.volumes.label": {
                     "type": "string",
@@ -2223,6 +2301,9 @@
                     "enum": [
                         "CreatedTime",
                         "VolumeName"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.volumes.sortBy": {
@@ -2232,23 +2313,35 @@
                     "enum": [
                         "CreatedTime",
                         "Label"
+                    ],
+                    "tags": [
+                        "advanced"
                     ]
                 },
                 "containers.imageBuildContextPath": {
                     "type": "string",
                     "default": "",
                     "description": "%vscode-containers.config.containers.imageBuildContextPath%",
-                    "scope": "machine-overridable"
+                    "scope": "machine-overridable",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.truncateLongRegistryPaths": {
                     "type": "boolean",
                     "default": false,
-                    "description": "%vscode-containers.config.containers.truncateLongRegistryPaths%"
+                    "description": "%vscode-containers.config.containers.truncateLongRegistryPaths%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.truncateMaxLength": {
                     "type": "number",
                     "default": 10,
-                    "description": "%vscode-containers.config.containers.truncateMaxLength%"
+                    "description": "%vscode-containers.config.containers.truncateMaxLength%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.environment": {
                     "type": "object",
@@ -2256,7 +2349,10 @@
                         "type": "string"
                     },
                     "description": "%vscode-containers.config.containers.environment%",
-                    "scope": "machine-overridable"
+                    "scope": "machine-overridable",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.deprecatedMaintainer": {
                     "scope": "resource",
@@ -2267,7 +2363,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.deprecatedMaintainer%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.deprecatedMaintainer%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.emptyContinuationLine": {
                     "scope": "resource",
@@ -2278,7 +2377,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.emptyContinuationLine%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.emptyContinuationLine%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.directiveCasing": {
                     "scope": "resource",
@@ -2289,7 +2391,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.directiveCasing%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.directiveCasing%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionCasing": {
                     "scope": "resource",
@@ -2300,7 +2405,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionCasing%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionCasing%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionCmdMultiple": {
                     "scope": "resource",
@@ -2311,7 +2419,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionCmdMultiple%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionCmdMultiple%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionEntrypointMultiple": {
                     "scope": "resource",
@@ -2322,7 +2433,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionEntrypointMultiple%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionEntrypointMultiple%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionHealthcheckMultiple": {
                     "scope": "resource",
@@ -2333,7 +2447,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionHealthcheckMultiple%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionHealthcheckMultiple%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionJSONInSingleQuotes": {
                     "scope": "resource",
@@ -2344,7 +2461,10 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionJsonInSingleQuotes%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionJsonInSingleQuotes%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.diagnostics.instructionWorkdirRelative": {
                     "scope": "resource",
@@ -2355,13 +2475,19 @@
                         "warning",
                         "error"
                     ],
-                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionWorkdirRelative%"
+                    "description": "%vscode-containers.config.docker.languageserver.diagnostics.instructionWorkdirRelative%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "docker.languageserver.formatter.ignoreMultilineInstructions": {
                     "scope": "resource",
                     "type": "boolean",
                     "default": false,
-                    "description": "%vscode-containers.config.docker.languageserver.formatter.ignoreMultilineInstructions%"
+                    "description": "%vscode-containers.config.docker.languageserver.formatter.ignoreMultilineInstructions%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.composeBuild": {
                     "type": "boolean",
@@ -2376,11 +2502,17 @@
                 "containers.showRemoteWorkspaceWarning": {
                     "type": "boolean",
                     "default": true,
-                    "description": "%vscode-containers.config.containers.showRemoteWorkspaceWarning%"
+                    "description": "%vscode-containers.config.containers.showRemoteWorkspaceWarning%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.scaffolding.templatePath": {
                     "type": "string",
-                    "description": "%vscode-containers.config.containers.scaffolding.templatePath%"
+                    "description": "%vscode-containers.config.containers.scaffolding.templatePath%",
+                    "tags": [
+                        "advanced"
+                    ]
                 },
                 "containers.containerCommand": {
                     "type": "string",


### PR DESCRIPTION
Fixes #296. I opted not to bump the minimum VSCode version to 1.106 where this setting is supported, because nothing will break in downlevel VSCode versions.

Summary of changes courtesy of Copilot:

1. **containers.promptForRegistryWhenPushingImages** - NOT advanced
2. **containers.commands.build** - **ADVANCED**
3. **containers.commands.run** - **ADVANCED**
4. **containers.commands.runInteractive** - **ADVANCED**
5. **containers.commands.attach** - **ADVANCED**
6. **containers.commands.logs** - **ADVANCED**
7. **containers.commands.composeUp** - **ADVANCED**
8. **containers.commands.composeUpSubset** - **ADVANCED**
9. **containers.commands.composeDown** - **ADVANCED**
10. **containers.commands.composeDownSubset** - **ADVANCED**
11. **containers.containers.groupBy** - **ADVANCED**
12. **containers.containers.groupByLabel** - **ADVANCED**
13. **containers.containers.description** - **ADVANCED**
14. **containers.containers.label** - **ADVANCED**
15. **containers.containers.sortBy** - **ADVANCED**
16. **containers.contexts.description** - **ADVANCED**
17. **containers.contexts.label** - **ADVANCED**
18. **containers.contexts.showInStatusBar** - NOT advanced
19. **containers.images.groupBy** - **ADVANCED**
20. **containers.images.description** - **ADVANCED**
21. **containers.images.label** - **ADVANCED**
22. **containers.images.sortBy** - **ADVANCED**
23. **containers.images.checkForOutdatedImages** - NOT advanced
24. **containers.networks.groupBy** - **ADVANCED**
25. **containers.networks.description** - **ADVANCED**
26. **containers.networks.showBuiltInNetworks** - NOT advanced
27. **containers.networks.label** - **ADVANCED**
28. **containers.networks.sortBy** - **ADVANCED**
29. **containers.volumes.groupBy** - **ADVANCED**
30. **containers.volumes.description** - **ADVANCED**
31. **containers.volumes.label** - **ADVANCED**
32. **containers.volumes.sortBy** - **ADVANCED**
33. **containers.imageBuildContextPath** - **ADVANCED**
34. **containers.truncateLongRegistryPaths** - **ADVANCED**
35. **containers.truncateMaxLength** - **ADVANCED**
36. **containers.environment** - **ADVANCED**
37. **docker.languageserver.diagnostics.deprecatedMaintainer** - **ADVANCED**
38. **docker.languageserver.diagnostics.emptyContinuationLine** - **ADVANCED**
39. **docker.languageserver.diagnostics.directiveCasing** - **ADVANCED**
40. **docker.languageserver.diagnostics.instructionCasing** - **ADVANCED**
41. **docker.languageserver.diagnostics.instructionCmdMultiple** - **ADVANCED**
42. **docker.languageserver.diagnostics.instructionEntrypointMultiple** - **ADVANCED**
43. **docker.languageserver.diagnostics.instructionHealthcheckMultiple** - **ADVANCED**
44. **docker.languageserver.diagnostics.instructionJSONInSingleQuotes** - **ADVANCED**
45. **docker.languageserver.diagnostics.instructionWorkdirRelative** - **ADVANCED**
46. **docker.languageserver.formatter.ignoreMultilineInstructions** - **ADVANCED**
47. **containers.composeBuild** - NOT advanced
48. **containers.composeDetached** - NOT advanced
49. **containers.showRemoteWorkspaceWarning** - **ADVANCED**
50. **containers.scaffolding.templatePath** - **ADVANCED**
51. **containers.containerCommand** - NOT advanced
52. **containers.composeCommand** - NOT advanced
53. **containers.enableComposeLanguageService** - NOT advanced
54. **containers.containerClient** - NOT advanced
55. **containers.orchestratorClient** - NOT advanced

**Summary:** Out of 55 total settings, **44 are marked as advanced** and **11 are not advanced**.