### PR TITLE
Remove README section about Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ You can rearrange the view panes by dragging them up or down with a mouse and us
 
 ![Customize Container Explorer](resources/readme/container-view-rearrange.gif)
 
-### Copilot tools
-
-The extension includes tools for Copilot to help manage your containers, directly from chat!
-
-![Copilot tools](resources/readme/copilot-tools.gif)
-
 ### Container commands
 
 Many of the most common container commands are built right into the Command Palette:


### PR DESCRIPTION
Fixes #348. The README [image](https://github.com/microsoft/vscode-containers/blob/main/resources/readme/copilot-tools.gif) needs to be removed later, as it is still in use by the existing installations of the extension (README images are not bundled with the VSIX but loaded as-needed directly from GitHub).

Corresponding docs PR: https://github.com/microsoft/vscode-docs/pull/9289