### PR TITLE
Add wslc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0 - Unreleased
+### Added
+* Added support for `wslc` (Windows Subsystem for Linux Container CLI) as an alternative container runtime. Windows-only.
+
 ## 2.4.5 - 28 May 2026
 ### Changed
 * Deployments to Azure App Service are now performed through the [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice), simplifying the deployment flow and reducing duplicated code. [#473](https://github.com/microsoft/vscode-containers/pull/473)

--- a/package.json
+++ b/package.json
@@ -2545,12 +2545,14 @@
                     "enum": [
                         "",
                         "com.microsoft.visualstudio.containers.docker",
-                        "com.microsoft.visualstudio.containers.podman"
+                        "com.microsoft.visualstudio.containers.podman",
+                        "com.microsoft.visualstudio.containers.wslc"
                     ],
                     "enumItemLabels": [
                         "Default",
                         "Docker",
-                        "Podman"
+                        "Podman",
+                        "WSLC (Windows only, preview)"
                     ]
                 },
                 "containers.orchestratorClient": {
@@ -3369,7 +3371,7 @@
         "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.8",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-utils": "^4.1.0",
-        "@microsoft/vscode-container-client": "^0.5.3",
+        "@microsoft/vscode-container-client": "^0.6.0",
         "@microsoft/vscode-docker-registries": "^0.4.2",
         "@microsoft/vscode-processutils": "^0.2.1",
         "dayjs": "^1.11.7",

--- a/package.nls.json
+++ b/package.nls.json
@@ -206,7 +206,7 @@
     "vscode-containers.config.containers.containerCommand": "Command to use for container actions (e.g. `docker` command). If the executable path contains whitespace, it needs to be quoted appropriately. If unset, the extension will attempt to auto-detect the command to use.",
     "vscode-containers.config.containers.composeCommand": "Command to use for compose actions (e.g. `docker-compose`, `docker compose`, etc. command). If the executable path contains whitespace, it needs to be quoted appropriately. If unset, the extension will attempt to auto-detect the command to use.",
     "vscode-containers.config.containers.enableComposeLanguageService": "Whether or not to enable the Compose Language Service. Changing requires a restart to take effect.",
-    "vscode-containers.config.containers.containerClient": "Which container client to use. If not specified, Docker will be used. Changing requires a restart to take effect.",
+    "vscode-containers.config.containers.containerClient": "Which container client to use. If not specified, Docker will be used. The `wslc` (WSLC) option is only available on Windows. Changing requires a restart to take effect.",
     "vscode-containers.config.containers.orchestratorClient": "Which container orchestrator client to use. If not specified, Docker Compose will be used. Changing requires a restart to take effect.",
     "vscode-containers.config.deprecated": "This setting has been deprecated and will be removed in a future release.",
     "vscode-containers.commands.compose.down": "Compose Down",

--- a/src/commands/chooseContainerRuntime.ts
+++ b/src/commands/chooseContainerRuntime.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { DockerClient, DockerComposeClient, IContainerOrchestratorClient, IContainersClient, PodmanClient, PodmanComposeClient } from '@microsoft/vscode-container-client';
+import { DockerClient, DockerComposeClient, IContainerOrchestratorClient, IContainersClient, PodmanClient, PodmanComposeClient, WslcClient } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { configPrefix } from '../constants';
+import { isWindows } from '../utils/osUtils';
 
 interface IContainerRuntimePair {
     containerClient: IContainersClient;
-    orchestratorClient: IContainerOrchestratorClient;
+    // wslc has no compose/orchestrator counterpart, so the orchestrator half is optional.
+    orchestratorClient?: IContainerOrchestratorClient;
 }
 
 export async function chooseContainerRuntime(context: IActionContext): Promise<void> {
@@ -18,6 +20,12 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
         { containerClient: new DockerClient(), orchestratorClient: new DockerComposeClient() },
         { containerClient: new PodmanClient(), orchestratorClient: new PodmanComposeClient() },
     ];
+
+    // WSLC is Windows-only and has no orchestrator counterpart; selecting it leaves the
+    // orchestrator (compose) setting unchanged.
+    if (isWindows()) {
+        runtimePairOptions.push({ containerClient: new WslcClient() });
+    }
 
     const configuration = vscode.workspace.getConfiguration(configPrefix);
     const oldContainerClientValue = configuration.get<string | undefined>('containerClient');
@@ -38,12 +46,21 @@ export async function chooseContainerRuntime(context: IActionContext): Promise<v
 
     context.telemetry.properties.selectedRuntime = selectedRuntimePair.data.containerClient.displayName;
 
-    if (oldContainerClientValue === selectedRuntimePair.data.containerClient.id && oldOrchestratorClientValue === selectedRuntimePair.data.orchestratorClient.id) {
+    const selectedContainerClient = selectedRuntimePair.data.containerClient;
+    const selectedOrchestratorClient = selectedRuntimePair.data.orchestratorClient;
+
+    const containerClientUnchanged = oldContainerClientValue === selectedContainerClient.id;
+    // If the selected runtime has no orchestrator, the orchestrator setting is left as-is.
+    const orchestratorClientUnchanged = !selectedOrchestratorClient || oldOrchestratorClientValue === selectedOrchestratorClient.id;
+
+    if (containerClientUnchanged && orchestratorClientUnchanged) {
         // If there's no change, we don't need to do anything
         return;
     } else {
-        await configuration.update('containerClient', selectedRuntimePair.data.containerClient.id, vscode.ConfigurationTarget.Global);
-        await configuration.update('orchestratorClient', selectedRuntimePair.data.orchestratorClient.id, vscode.ConfigurationTarget.Global);
+        await configuration.update('containerClient', selectedContainerClient.id, vscode.ConfigurationTarget.Global);
+        if (selectedOrchestratorClient) {
+            await configuration.update('orchestratorClient', selectedOrchestratorClient.id, vscode.ConfigurationTarget.Global);
+        }
     }
 
     const reload: vscode.MessageItem = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { AutoConfigurableDockerClient } from './runtimes/clients/AutoConfigurabl
 import { AutoConfigurableDockerComposeClient } from './runtimes/clients/AutoConfigurableDockerComposeClient';
 import { AutoConfigurablePodmanClient } from './runtimes/clients/AutoConfigurablePodmanClient';
 import { AutoConfigurablePodmanComposeClient } from './runtimes/clients/AutoConfigurablePodmanComposeClient';
+import { AutoConfigurableWslcClient } from './runtimes/clients/AutoConfigurableWslcClient';
 import { ContainerRuntimeManager } from './runtimes/ContainerRuntimeManager';
 import { ContainerFilesProvider } from './runtimes/files/ContainerFilesProvider';
 import { OrchestratorRuntimeManager } from './runtimes/OrchestratorRuntimeManager';
@@ -34,6 +35,7 @@ import { AzExtLogOutputChannelWrapper } from './utils/AzExtLogOutputChannelWrapp
 import { logDockerEnvironment, logSystemInfo } from './utils/diagnostics';
 import { getLanguageClient } from './utils/lazyPackages';
 import { migrateDockerToContainersSettingsIfNeeded } from './utils/migration/settings';
+import { isWindows } from './utils/osUtils';
 import { registerDockerContextStatusBarEvent } from './utils/registerDockerContextStatusBarItems';
 
 let dockerfileLanguageClient: LanguageClient;
@@ -198,6 +200,8 @@ function registerContainerClients(): void {
     const podmanClient = new AutoConfigurablePodmanClient();
     const dockerComposeClient = new AutoConfigurableDockerComposeClient();
     const podmanComposeClient = new AutoConfigurablePodmanComposeClient();
+    // WSLC is only available on Windows; only register the client on Windows hosts.
+    const wslcClient = isWindows() ? new AutoConfigurableWslcClient() : undefined;
 
     // Register the clients
     ext.context.subscriptions.push(
@@ -207,6 +211,12 @@ function registerContainerClients(): void {
         ext.orchestratorManager.registerRuntimeClient(podmanComposeClient),
     );
 
+    if (wslcClient) {
+        ext.context.subscriptions.push(
+            ext.runtimeManager.registerRuntimeClient(wslcClient),
+        );
+    }
+
     // Register an event to watch for changes to config, reconfigure if needed
     registerEvent('vscode-containers.command.changed', vscode.workspace.onDidChangeConfiguration, (actionContext: IActionContext, e: vscode.ConfigurationChangeEvent) => {
         actionContext.telemetry.suppressAll = true;
@@ -215,6 +225,7 @@ function registerContainerClients(): void {
         if (e.affectsConfiguration(`${configPrefix}.containerCommand`)) {
             dockerClient.reconfigure();
             podmanClient.reconfigure();
+            wslcClient?.reconfigure();
         }
 
         if (e.affectsConfiguration(`${configPrefix}.composeCommand`)) {

--- a/src/runtimes/RuntimeManager.ts
+++ b/src/runtimes/RuntimeManager.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ClientIdentity } from '@microsoft/vscode-container-client';
+import { ClientIdentity, WslcClient } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { configPrefix } from '../constants';
+import { isWindows } from '../utils/osUtils';
 import { TimeoutPromiseSource } from '../utils/promiseUtils';
 
 export abstract class RuntimeManager<TClient extends ClientIdentity> extends vscode.Disposable {
@@ -64,6 +65,10 @@ export abstract class RuntimeManager<TClient extends ClientIdentity> extends vsc
     protected abstract getDefaultClient(): TClient;
 
     protected waitForClientToBeRegistered(clientId: string): Promise<TClient> {
+        if (clientId === WslcClient.ClientId && !isWindows()) {
+            return Promise.reject(new Error(vscode.l10n.t('WSLC is only available on Windows.')));
+        }
+
         if (this._runtimeClients.has(clientId)) {
             // If it's already registered, resolve immediately
             return Promise.resolve(this._runtimeClients.get(clientId));

--- a/src/runtimes/clients/AutoConfigurableWslcClient.ts
+++ b/src/runtimes/clients/AutoConfigurableWslcClient.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WslcClient } from '@microsoft/vscode-container-client';
+import { configPrefix } from '../../constants';
+import { ext } from '../../extensionVariables';
+import { AutoConfigurableClient } from './AutoConfigurableClient';
+
+/**
+ * IMPORTANT NOTE: This class mirrors {@link AutoConfigurableDockerClient} and
+ * {@link AutoConfigurablePodmanClient} in shape, but deliberately ignores the
+ * shared `containers.containerCommand` setting: wslc is a specifically named
+ * binary on the user's PATH and overriding the executable name only makes
+ * sense for the docker/podman aliases.
+ *
+ * WSLC (Windows Subsystem for Linux Container CLI) is only available on Windows;
+ * this client is only registered on Windows hosts.
+ */
+export class AutoConfigurableWslcClient extends WslcClient implements AutoConfigurableClient {
+    public constructor() {
+        super();
+        this.reconfigure();
+    }
+
+    public reconfigure(): void {
+        this.commandName = 'wslc';
+        ext.outputChannel.debug(`${configPrefix}: WSLC client command pinned to '${this.commandName}'`);
+    }
+}

--- a/src/tasks/netSdk/NetSdkRunTaskProvider.ts
+++ b/src/tasks/netSdk/NetSdkRunTaskProvider.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { promises as fs } from "fs";
 import * as path from "path";
 import { CancellationToken, CustomExecution, Task, TaskDefinition, TaskScope } from "vscode";
 import { DockerPseudoterminal } from "../DockerPseudoterminal";
@@ -10,7 +11,7 @@ import { DockerRunTask } from "../DockerRunTaskProvider";
 import { DockerTaskProvider } from '../DockerTaskProvider';
 import { DockerRunTaskContext } from '../TaskHelper';
 import { NetCoreRunTaskDefinition } from "../netcore/NetCoreTaskHelper";
-import { NetSdkRunTaskType, getNetSdkBuildCommand, getNetSdkRunCommand } from './netSdkTaskUtils';
+import { NetSdkRunTaskType, getNetSdkBuildCommand, getNetSdkImageArchivePath, getNetSdkLoadCommand, getNetSdkRunCommand, isWslcRuntimeSelected } from './netSdkTaskUtils';
 
 const NetSdkDebugTaskName = 'debug';
 
@@ -27,30 +28,57 @@ export class NetSdkRunTaskProvider extends DockerTaskProvider {
     protected async executeTaskInternal(context: DockerRunTaskContext, task: DockerRunTask): Promise<void> {
         const projectPath = task.definition.netCore?.appProject;
         const projectFolderPath = path.dirname(projectPath);
+        const imageName = task.definition.dockerRun.image;
 
-        // use dotnet to build the image
-        const { command: buildCommand, args: buildArgs } = await getNetSdkBuildCommand();
-        await context.terminal.execAsyncInTerminal(
-            buildCommand,
-            buildArgs,
-            {
-                folder: context.folder,
-                token: context.cancellationToken,
-                cwd: projectFolderPath,
-            }
-        );
+        // wslc can't be a .NET SDK `LocalRegistry` target, so for wslc the image is published to a
+        // temporary tar archive and loaded into the runtime before running. The path is generated
+        // once (with a GUID to avoid collisions) and shared by the build and load steps.
+        const imageArchivePath = isWslcRuntimeSelected() ? getNetSdkImageArchivePath(imageName) : undefined;
 
-        // use docker run to run the image
-        const { command: runCommand, args: runArgs } = await getNetSdkRunCommand(task.definition.dockerRun.image);
-        await context.terminal.execAsyncInTerminal(
-            runCommand,
-            runArgs,
-            {
-                folder: context.folder,
-                token: context.cancellationToken,
-                cwd: projectFolderPath,
+        try {
+            // use dotnet to build the image
+            const { command: buildCommand, args: buildArgs } = await getNetSdkBuildCommand(imageArchivePath);
+            await context.terminal.execAsyncInTerminal(
+                buildCommand,
+                buildArgs,
+                {
+                    folder: context.folder,
+                    token: context.cancellationToken,
+                    cwd: projectFolderPath,
+                }
+            );
+
+            // for wslc, load the tar archive produced by the build into the runtime
+            if (imageArchivePath) {
+                const { command: loadCommand, args: loadArgs } = await getNetSdkLoadCommand(imageArchivePath);
+                await context.terminal.execAsyncInTerminal(
+                    loadCommand,
+                    loadArgs,
+                    {
+                        folder: context.folder,
+                        token: context.cancellationToken,
+                        cwd: projectFolderPath,
+                    }
+                );
             }
-        );
+
+            // use docker run to run the image
+            const { command: runCommand, args: runArgs } = await getNetSdkRunCommand(imageName);
+            await context.terminal.execAsyncInTerminal(
+                runCommand,
+                runArgs,
+                {
+                    folder: context.folder,
+                    token: context.cancellationToken,
+                    cwd: projectFolderPath,
+                }
+            );
+        } finally {
+            // best-effort cleanup of the temporary image archive (wslc only)
+            if (imageArchivePath) {
+                await fs.rm(imageArchivePath, { force: true }).catch(() => { /* ignore cleanup failures */ });
+            }
+        }
 
         return Promise.resolve();
     }

--- a/src/tasks/netSdk/netSdkTaskUtils.ts
+++ b/src/tasks/netSdk/netSdkTaskUtils.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DockerClient, PodmanClient, RunContainerBindMount, RunContainerCommandOptions } from "@microsoft/vscode-container-client";
+import { DockerClient, PodmanClient, RunContainerBindMount, RunContainerCommandOptions, WslcClient } from "@microsoft/vscode-container-client";
 import { CommandLineArgs, composeArgs, withArg, withNamedArg } from '@microsoft/vscode-processutils';
+import * as crypto from 'crypto';
 import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { configPrefix } from "../../constants";
 import { vsDbgInstallBasePath } from "../../debugging/netcore/VsDbgHelper";
@@ -32,7 +34,7 @@ export type RidCpuArchitecture =
 export const NetSdkRunTaskType = 'dotnet-container-sdk';
 const NetSdkDefaultImageTag = 'dev'; // intentionally default to dev tag for phase 1 of this feature
 
-export async function getNetSdkBuildCommand(): Promise<{ command: string, args: CommandLineArgs }> {
+export async function getNetSdkBuildCommand(archiveOutputPath?: string): Promise<{ command: string, args: CommandLineArgs }> {
     const args = composeArgs(
         withArg('publish'),
         withNamedArg('--os', await normalizeOsToRidOs()),
@@ -40,10 +42,30 @@ export async function getNetSdkBuildCommand(): Promise<{ command: string, args: 
         withArg('/t:PublishContainer'),
         withNamedArg('--configuration', 'Debug'),
         withNamedArg('-p:ContainerImageTag', NetSdkDefaultImageTag, { assignValue: true }),
-        withNamedArg('-p:LocalRegistry', getLocalRegistry(), { assignValue: true }),
+        // wslc can't be a .NET SDK `LocalRegistry` target. When an archive path is provided (wslc),
+        // publish the image to that tar so it can be loaded separately; otherwise load it directly
+        // into the runtime via `LocalRegistry`.
+        archiveOutputPath
+            ? withNamedArg('-p:ContainerArchiveOutputPath', archiveOutputPath, { assignValue: true })
+            : withNamedArg('-p:LocalRegistry', getLocalRegistry(), { assignValue: true }),
     )();
 
     return { command: 'dotnet', args: args };
+}
+
+/**
+ * Builds the command that loads the tar archive produced by {@link getNetSdkBuildCommand} into
+ * the selected runtime. Only needed for wslc, which cannot be targeted directly by the .NET SDK's
+ * `LocalRegistry` property.
+ */
+export async function getNetSdkLoadCommand(archiveInputPath: string): Promise<{ command: string, args: CommandLineArgs }> {
+    const client = await ext.runtimeManager.getClient();
+    const args = composeArgs(
+        withArg('load'),
+        withNamedArg('--input', archiveInputPath),
+    )();
+
+    return { command: client.commandName, args: args };
 }
 
 export async function getNetSdkRunCommand(imageName: string): Promise<{ command: string, args: CommandLineArgs }> {
@@ -95,10 +117,7 @@ export async function normalizeArchitectureToRidArchitecture(): Promise<RidCpuAr
  * See https://learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration#localregistry
  */
 function getLocalRegistry(): 'Docker' | 'Podman' | undefined {
-    const config = vscode.workspace.getConfiguration(configPrefix);
-    const containerClientId = config.get<string>('containerClient', '');
-
-    switch (containerClientId) {
+    switch (getSelectedContainerClientId()) {
         case DockerClient.ClientId:
             return 'Docker';
         case PodmanClient.ClientId:
@@ -106,6 +125,30 @@ function getLocalRegistry(): 'Docker' | 'Podman' | undefined {
         default:
             return undefined;
     }
+}
+
+function getSelectedContainerClientId(): string {
+    const config = vscode.workspace.getConfiguration(configPrefix);
+    return config.get<string>('containerClient', '');
+}
+
+/**
+ * Whether the wslc runtime is the selected container client. wslc cannot be a .NET SDK
+ * `LocalRegistry` target, so the build/run task publishes to a tar archive and loads it instead.
+ */
+export function isWslcRuntimeSelected(): boolean {
+    return getSelectedContainerClientId() === WslcClient.ClientId;
+}
+
+/**
+ * A unique temp path for the image tar archive the .NET SDK emits for wslc (via
+ * `ContainerArchiveOutputPath`) and that the subsequent `wslc load` step reads. A GUID is
+ * included to avoid collisions between concurrent or repeated task runs. The caller is
+ * responsible for deleting the file once the load completes.
+ */
+export function getNetSdkImageArchivePath(imageName: string): string {
+    const safeName = getImageNameWithTag(imageName, NetSdkDefaultImageTag).replace(/[^a-z0-9_.-]/gi, '_');
+    return path.join(os.tmpdir(), `${safeName}-${crypto.randomUUID()}.tar`);
 }
 
 /**

--- a/src/telemetry/registerRuntimeTelemetryHandler.ts
+++ b/src/telemetry/registerRuntimeTelemetryHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerTelemetryHandler } from '@microsoft/vscode-azext-utils';
-import { DockerClient, DockerComposeClient, PodmanClient, PodmanComposeClient } from '@microsoft/vscode-container-client';
+import { DockerClient, DockerComposeClient, PodmanClient, PodmanComposeClient, WslcClient } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { configPrefix } from '../constants';
 
@@ -24,6 +24,9 @@ export function registerRuntimeTelemetryHandler(ctx: vscode.ExtensionContext): v
                 break;
             case PodmanClient.ClientId:
                 context.telemetry.properties.containerClient = PodmanClient.prototype.constructor.name;
+                break;
+            case WslcClient.ClientId:
+                context.telemetry.properties.containerClient = WslcClient.prototype.constructor.name;
                 break;
             default:
                 context.telemetry.properties.containerClient = 'unknown';


### PR DESCRIPTION
###  Add  wslc  (WSL Container CLI) as a Windows-only container runtime (preview)

 Description

 Registers the new  WslcClient  from  @microsoft/vscode-container-client  as a selectable, Windows-only container runtime, exposed as "WSLC (Windows  only, preview)". It's treated as an alternative to Docker/Podman, mirroring the existing auto-configurable client pattern.

 Depends on microsoft/vscode-docker-extensibility# ( @microsoft/vscode-container-client@^0.6.0 ).

###  What's added / changed

 •  AutoConfigurableWslcClient  — mirrors the Docker/Podman auto-configurable clients, but pins the command to  wslc  (ignores the shared     containers.containerCommand  override, since wslc is a specific named binary).
 •  extension.ts  — registers the wslc client only on Windows ( isWindows()  gate), and wires up  reconfigure .
 •  RuntimeManager  — if  wslc  is selected on a non-Windows host, rejects with a clear "WSLC is only available on Windows" error instead of a confusing    timeout.


###  .NET SDK container task support

 The .NET SDK's  LocalRegistry  publish target only supports Docker/Podman. To support wslc, the SDK run task now:

 1. Publishes the image to a temporary tar archive ( -p:ContainerArchiveOutputPath=<tmp>\<image>-<guid>.tar ) instead of  -p:LocalRegistry ,
 2. Loads it with  wslc load --input <tar> ,
 3. Runs it — then deletes the temp tar in a  finally  (GUID-named to avoid collisions).

 Docker/Podman continue to use  LocalRegistry  unchanged.

#501 