### PR TITLE
Bump all packages to 1.0.0

### DIFF
--- a/packages/compose-language-service/CHANGELOG.md
+++ b/packages/compose-language-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 - 20 July 2026
+### Changed
+* The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
+
 ## 0.5.0 - 9 February 2026
 ### Breaking Changes
 * `TelemetryEvent`, `AlternateYamlLanguageServiceClientCapabilities`, and `DocumentSettings*` types have moved from `lib/client/*` to `@microsoft/compose-language-service/client`.

--- a/packages/compose-language-service/CHANGELOG.md
+++ b/packages/compose-language-service/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - 20 July 2026
+## 1.0.0 - 21 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
 

--- a/packages/compose-language-service/package.json
+++ b/packages/compose-language-service/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/compose-language-service",
     "author": "Microsoft Corporation",
-    "version": "0.5.0",
+    "version": "1.0.0",
     "publisher": "ms-azuretools",
     "description": "Language service for Docker Compose documents",
     "license": "MIT",

--- a/packages/vscode-container-client/CHANGELOG.md
+++ b/packages/vscode-container-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - 20 July 2026
+## 1.0.0 - 21 July 2026
 ### Breaking Changes
 * Added a required readonly `defaultCommandName` property to `ClientIdentity` (and therefore the `ContainerClient` interface implemented by all clients). Consumers implementing these interfaces directly must now provide this property; those extending `ConfigurableClient` get it automatically.
 

--- a/packages/vscode-container-client/CHANGELOG.md
+++ b/packages/vscode-container-client/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0 - 20 July 2026
+### Breaking Changes
+* Added a required readonly `defaultCommandName` property to `ClientIdentity` (and therefore the `ContainerClient` interface implemented by all clients). Consumers implementing these interfaces directly must now provide this property; those extending `ConfigurableClient` get it automatically.
+
+### Changed
+* The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers).
+* The package now declares a minimum Node.js engine of 22.
+
 ## 0.5.4 - 22 April 2026
 ### Changed
 * Removed runtime imports of `'vscode'`. [#359](https://github.com/microsoft/vscode-docker-extensibility/pull/359)

--- a/packages/vscode-container-client/package.json
+++ b/packages/vscode-container-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-container-client",
     "author": "Microsoft Corporation",
-    "version": "0.5.4",
+    "version": "1.0.0",
     "description": "Extensibility model for implementing container runtime providers (shared by VS and VS Code)",
     "license": "MIT",
     "repository": {
@@ -26,6 +26,9 @@
         "testintegration": "mocha --grep \"(integration)\"",
         "testintegrationcov": "pnpx nyc --reporter=html mocha --grep \"(integration)\"",
         "clean": "node ../../scripts/clean.mjs"
+    },
+    "engines": {
+        "node": ">=22"
     },
     "dependencies": {
         "@microsoft/vscode-processutils": "workspace:*",

--- a/packages/vscode-docker-registries/CHANGELOG.md
+++ b/packages/vscode-docker-registries/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - 20 July 2026
+## 1.0.0 - 21 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
 

--- a/packages/vscode-docker-registries/CHANGELOG.md
+++ b/packages/vscode-docker-registries/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 - 20 July 2026
+### Changed
+* The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
+
 ## 0.4.2 - 16 April 2026
 ### Fixed
 * Fixed an issue where some requests would fail. [#354](https://github.com/microsoft/vscode-docker-extensibility/issues/354)

--- a/packages/vscode-docker-registries/package.json
+++ b/packages/vscode-docker-registries/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-docker-registries",
     "author": "Microsoft Corporation",
-    "version": "0.4.2",
+    "version": "1.0.0",
     "description": "Extensibility model for contributing registry providers to the Container Tools extension for Visual Studio Code",
     "license": "MIT",
     "repository": {

--- a/packages/vscode-inproc-mcp/CHANGELOG.md
+++ b/packages/vscode-inproc-mcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 - 20 July 2026
+### Changed
+* The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
+
 ## 0.3.0 - 9 February 2026
 ### Breaking Changes
 * Switching from `zod/v4` to `zod/mini` for better tree shaking. [#337](https://github.com/microsoft/vscode-docker-extensibility/pull/337)

--- a/packages/vscode-inproc-mcp/CHANGELOG.md
+++ b/packages/vscode-inproc-mcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - 20 July 2026
+## 1.0.0 - 21 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
 

--- a/packages/vscode-inproc-mcp/package.json
+++ b/packages/vscode-inproc-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-inproc-mcp",
     "author": "Microsoft Corporation",
-    "version": "0.3.0",
+    "version": "1.0.0",
     "description": "Library support for building MCP servers, primarily for use in VS Code.",
     "license": "MIT",
     "repository": {

--- a/packages/vscode-processutils/CHANGELOG.md
+++ b/packages/vscode-processutils/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - 20 July 2026
+## 1.0.0 - 21 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
 * The package now declares a minimum Node.js engine of 22.

--- a/packages/vscode-processutils/CHANGELOG.md
+++ b/packages/vscode-processutils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0 - 20 July 2026
+### Changed
+* The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
+* The package now declares a minimum Node.js engine of 22.
+
 ## 0.2.2 - 22 April 2026
 ### Changed
 * Removed runtime imports of `'vscode'`. [#358](https://github.com/microsoft/vscode-docker-extensibility/pull/358)

--- a/packages/vscode-processutils/package.json
+++ b/packages/vscode-processutils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-processutils",
     "author": "Microsoft Corporation",
-    "version": "0.2.2",
+    "version": "1.0.0",
     "description": "Library support for building command lines and running external processes, primarily for use in VS Code.",
     "license": "MIT",
     "repository": {
@@ -25,6 +25,9 @@
         "test": "mocha",
         "testintegration": "mocha --grep \"(integration)\"",
         "clean": "node ../../scripts/clean.mjs"
+    },
+    "engines": {
+        "node": ">=22"
     },
     "dependencies": {
         "tree-kill": "^1.2.2",


### PR DESCRIPTION
Bumps the version of every package under `/packages` to `1.0.0` and updates each changelog (release date: 20 July 2026).

## Version bumps
| Package | Old | New |
| --- | --- | --- |
| `@microsoft/vscode-container-client` | 0.5.4 | 1.0.0 |
| `@microsoft/vscode-processutils` | 0.2.2 | 1.0.0 |
| `@microsoft/compose-language-service` | 0.5.0 | 1.0.0 |
| `@microsoft/vscode-docker-registries` | 0.4.2 | 1.0.0 |
| `@microsoft/vscode-inproc-mcp` | 0.3.0 | 1.0.0 |

## Notes
- **vscode-container-client** is a genuine breaking release: it adds a required readonly `defaultCommandName` property to `ClientIdentity` (and therefore the `ContainerClient` interface implemented by all clients). Consumers implementing those interfaces directly must now supply it; those extending `ConfigurableClient` get it for free.
- **vscode-container-client** and **vscode-processutils** now declare a minimum Node.js engine of `>=22` in `package.json`.
- For **compose-language-service**, **vscode-docker-registries**, and **vscode-inproc-mcp**, `1.0.0` is *not* a breaking API change — the bump only reflects that the repository has been relocated to `microsoft/vscode-containers`.

The workspace packages are referenced via `link:` in `pnpm-lock.yaml`, so no lockfile changes are needed.