### PR TITLE
Fix spawnStreamAsync hang: end provided pipes on failure paths without truncating output

### DIFF
--- a/packages/vscode-processutils/CHANGELOG.md
+++ b/packages/vscode-processutils/CHANGELOG.md
@@ -3,6 +3,9 @@
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
 * The package now declares a minimum Node.js engine of 22.
 
+### Fixed
+* `spawnStreamAsync` now ends caller-provided `stdOutPipe`/`stdErrPipe` streams on the spawn `error` (e.g. `ENOENT`) and pre-spawn failure paths, so awaiting an `AccumulatorStream` after a rejection no longer hangs. [#540](https://github.com/microsoft/vscode-containers/issues/540)
+
 ## 0.2.2 - 22 April 2026
 ### Changed
 * Removed runtime imports of `'vscode'`. [#358](https://github.com/microsoft/vscode-docker-extensibility/pull/358)

--- a/packages/vscode-processutils/src/test/spawnStreamAsync.test.ts
+++ b/packages/vscode-processutils/src/test/spawnStreamAsync.test.ts
@@ -4,10 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
+import * as stream from 'stream';
 import { AccumulatorStream } from '../utils/AccumulatorStream';
+import { CancellationError } from '../utils/CancellationError';
+import { isChildProcessError } from '../utils/ChildProcessError';
 import { composeArgs, withArg, withNamedArg } from '../utils/commandLineBuilder';
 import { NoShell, Shell } from '../utils/Shell';
 import { spawnStreamAsync } from '../utils/spawnStreamAsync';
+import { CancellationTokenLike } from '../typings/CancellationTokenLike';
 
 // NOTE: This integration test requires Docker to be installed and running
 // It will automatically pull the `alpine:latest` image if not already present
@@ -86,5 +90,165 @@ describe('(integration) spawnStreamAsync', () => {
         expect(output).to.include('latest');
 
         expect(await errAccumulator.getString()).to.be.empty;
+    });
+});
+
+/**
+ * Races a promise against a timer so that a regression (an accumulator that never settles
+ * because its pipe was left open) fails the test deterministically instead of relying on
+ * Mocha's global timeout.
+ */
+async function settlesWithin<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle within ${ms}ms`)), ms);
+    });
+
+    try {
+        return await Promise.race([promise, timeout]);
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+describe('(unit) spawnStreamAsync pipe lifecycle', () => {
+    // A command that is guaranteed not to exist on PATH, to force a spawn `error` (ENOENT).
+    const nonexistentCommand = 'this-executable-should-not-exist-abcdef123456';
+
+    it('Should end provided pipes and settle the accumulator on spawn error (ENOENT)', async () => {
+        const outAccumulator = new AccumulatorStream();
+        const errAccumulator = new AccumulatorStream();
+
+        // `allowUnsafeExecutablePath` skips PATH resolution so the failure surfaces as a spawn
+        // `error` event (ENOENT) rather than a pre-spawn throw.
+        let rejected = false;
+        try {
+            await spawnStreamAsync(nonexistentCommand, [], {
+                stdOutPipe: outAccumulator,
+                stdErrPipe: errAccumulator,
+                allowUnsafeExecutablePath: true,
+            });
+        } catch {
+            rejected = true;
+        }
+
+        expect(rejected, 'spawnStreamAsync should reject on ENOENT').to.be.true;
+
+        // The key assertion: awaiting the accumulators must settle, not hang forever.
+        expect(await settlesWithin(outAccumulator.getString(), 5000, 'stdOutPipe')).to.equal('');
+        expect(await settlesWithin(errAccumulator.getString(), 5000, 'stdErrPipe')).to.equal('');
+    });
+
+    it('Should end provided pipes and settle the accumulators on non-zero exit', async () => {
+        const outAccumulator = new AccumulatorStream();
+        const errAccumulator = new AccumulatorStream();
+
+        let caught: unknown;
+        try {
+            await spawnStreamAsync(
+                process.execPath,
+                [
+                    '-e',
+                    'process.stderr.write("boom"); process.exit(3);',
+                ],
+                {
+                    stdOutPipe: outAccumulator,
+                    stdErrPipe: errAccumulator,
+                    allowUnsafeExecutablePath: true,
+                },
+            );
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(isChildProcessError(caught), 'should reject with a ChildProcessError').to.be.true;
+
+        // Both accumulators must settle, and stderr should contain the emitted output.
+        expect(await settlesWithin(outAccumulator.getString(), 5000, 'stdOutPipe')).to.equal('');
+        expect(await settlesWithin(errAccumulator.getString(), 5000, 'stdErrPipe')).to.equal('boom');
+    });
+
+    it('Should end provided pipes and settle the accumulator on pre-spawn cancellation', async () => {
+        const outAccumulator = new AccumulatorStream();
+        const errAccumulator = new AccumulatorStream();
+
+        const controller = new AbortController();
+        controller.abort();
+        const cancellationToken = CancellationTokenLike.fromAbortSignal(controller.signal);
+
+        let caught: unknown;
+        try {
+            await spawnStreamAsync(process.execPath, ['-v'], {
+                stdOutPipe: outAccumulator,
+                stdErrPipe: errAccumulator,
+                allowUnsafeExecutablePath: true,
+                cancellationToken,
+            });
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught, 'should reject with a CancellationError').to.be.instanceOf(CancellationError);
+
+        // Even though no child process ever started, the provided pipes must be ended so the
+        // accumulators settle.
+        expect(await settlesWithin(outAccumulator.getString(), 5000, 'stdOutPipe')).to.equal('');
+        expect(await settlesWithin(errAccumulator.getString(), 5000, 'stdErrPipe')).to.equal('');
+    });
+
+    it('Should not truncate output for a slow destination on non-zero exit', async () => {
+        // Regression guard: a slower/backpressured destination that is still consuming buffered
+        // data when the process exits must receive ALL output. Ending the pipe on the `exit`
+        // event (rather than letting `.pipe({ end: true })` end it on EOF) would race the drain,
+        // truncating trailing bytes and emitting a "write after end" error.
+        const expectedBytes = 2_000_000;
+
+        // A deliberately slow writable that applies heavy backpressure, so that unread data is
+        // still buffered when the process exits.
+        let received = 0;
+        let sawError: Error | undefined;
+        const slow = new stream.Writable({
+            highWaterMark: 16 * 1024,
+            write: (chunk: Buffer, _encoding: unknown, callback: () => void) => {
+                received += chunk.length;
+                setTimeout(callback, 10);
+            },
+        });
+        slow.on('error', (err) => { sawError = err; });
+
+        let caught: unknown;
+        try {
+            await spawnStreamAsync(
+                process.execPath,
+                ['-e', `process.stdout.write(Buffer.alloc(${expectedBytes}, 65)); process.exitCode = 3;`],
+                {
+                    stdOutPipe: slow,
+                    allowUnsafeExecutablePath: true,
+                },
+            );
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(isChildProcessError(caught), 'should reject with a ChildProcessError').to.be.true;
+
+        // Wait for the slow writable to finish (or error) rather than for an accumulator.
+        await settlesWithin(
+            new Promise<void>((resolve) => {
+                if (slow.writableFinished || sawError) {
+                    resolve();
+                } else {
+                    slow.once('finish', () => resolve());
+                    slow.once('error', () => resolve());
+                }
+            }),
+            30_000,
+            'slow destination',
+        );
+
+        expect(sawError, `destination should not receive a stream error (got: ${sawError?.message})`).to.be.undefined;
+        expect(received, 'destination must receive the full output without truncation').to.equal(expectedBytes);
     });
 });

--- a/packages/vscode-processutils/src/utils/spawnStreamAsync.ts
+++ b/packages/vscode-processutils/src/utils/spawnStreamAsync.ts
@@ -181,6 +181,7 @@ export async function spawnStreamAsync(
 
             if (cancellationToken.isCancellationRequested) {
                 reject(new CancellationError('Command cancelled', cancellationToken));
+                return;
             }
 
             reject(err);
@@ -196,6 +197,7 @@ export async function spawnStreamAsync(
 
             if (cancellationToken.isCancellationRequested) {
                 reject(new CancellationError('Command cancelled', cancellationToken));
+                return;
             }
 
             if (code === 0) {

--- a/packages/vscode-processutils/src/utils/spawnStreamAsync.ts
+++ b/packages/vscode-processutils/src/utils/spawnStreamAsync.ts
@@ -76,39 +76,61 @@ export async function spawnStreamAsync(
     const cancellationToken = options.cancellationToken ?? CancellationTokenLike.None;
     const shell = options.shellProvider?.getShellOrDefault(options.shell) ?? options.shell;
 
+    // Ends any caller-provided output/error pipes. This is used only on terminal paths where
+    // the child's stdio streams never deliver EOF to the destination (a pre-spawn throw, or a
+    // spawn `error` such as ENOENT), so that consumers awaiting an `AccumulatorStream` (which
+    // resolves only on the stream's `finish` event) always settle instead of hanging.
+    //
+    // It is intentionally NOT called on the normal `exit` path: there the `.pipe({ end: true })`
+    // wiring below already ends the destination once the source reaches EOF, i.e. after all
+    // output has drained. Ending manually on `exit` would race that drain and can truncate
+    // trailing output (and trigger "write after end") when a slower destination is still
+    // consuming buffered data.
+    const endPipes = () => {
+        options.stdOutPipe?.end();
+        options.stdErrPipe?.end();
+    };
+
     // If there is a shell provider, apply its quoting, otherwise just flatten arguments into strings
     const normalizedArgs: string[] = options.shellProvider?.quote(args) ?? args.map(arg => typeof arg === 'string' ? arg : arg.value);
 
-    // Cancellation check
-    if (cancellationToken.isCancellationRequested) {
-        throw new CancellationError('Command cancelled', cancellationToken);
-    }
-
     let finalCommand: string;
-    if (!!options.allowUnsafeExecutablePath) {
-        // If allowUnsafeExecutablePath is true, we assume the command is a full command line
-        // and we do not apply any quoting or checks.
-        finalCommand = command;
-    } else {
-        // Otherwise, we do some checks and quoting.
-        const safeCommand = getSafeExecPath(command, options.env?.PATH);
-        const quotedSafeCommand = quoteExecutableCommandIfNeeded(safeCommand);
-        finalCommand = !!shell ? quotedSafeCommand : safeCommand;
+    try {
+        // Cancellation check
+        if (cancellationToken.isCancellationRequested) {
+            throw new CancellationError('Command cancelled', cancellationToken);
+        }
 
-        // If we're on Windows and not using a shell, we must use `windowsVerbatimArguments`
-        options.windowsVerbatimArguments ??= os.platform() === 'win32' && !shell;
+        if (!!options.allowUnsafeExecutablePath) {
+            // If allowUnsafeExecutablePath is true, we assume the command is a full command line
+            // and we do not apply any quoting or checks.
+            finalCommand = command;
+        } else {
+            // Otherwise, we do some checks and quoting.
+            const safeCommand = getSafeExecPath(command, options.env?.PATH);
+            const quotedSafeCommand = quoteExecutableCommandIfNeeded(safeCommand);
+            finalCommand = !!shell ? quotedSafeCommand : safeCommand;
 
-        // If we use `windowsVerbatimArguments`, we must also set `argv0` to the quoted command
-        options.argv0 ??= options.windowsVerbatimArguments ? quotedSafeCommand : undefined;
-    }
+            // If we're on Windows and not using a shell, we must use `windowsVerbatimArguments`
+            options.windowsVerbatimArguments ??= os.platform() === 'win32' && !shell;
 
-    if (options.onCommand) {
-        options.onCommand([finalCommand, ...normalizedArgs].join(' '));
-    }
+            // If we use `windowsVerbatimArguments`, we must also set `argv0` to the quoted command
+            options.argv0 ??= options.windowsVerbatimArguments ? quotedSafeCommand : undefined;
+        }
 
-    // One last cancellation check before we start the process
-    if (cancellationToken.isCancellationRequested) {
-        throw new CancellationError('Command cancelled', cancellationToken);
+        if (options.onCommand) {
+            options.onCommand([finalCommand, ...normalizedArgs].join(' '));
+        }
+
+        // One last cancellation check before we start the process
+        if (cancellationToken.isCancellationRequested) {
+            throw new CancellationError('Command cancelled', cancellationToken);
+        }
+    } catch (err) {
+        // Any pre-spawn failure (already-cancelled token, executable-resolution failure) rejects
+        // before a child process or its streams exist, so end the caller-provided pipes here.
+        endPipes();
+        throw err;
     }
 
     const childProcess = spawn(
@@ -155,6 +177,7 @@ export async function spawnStreamAsync(
         // Reject the promise on an error event
         childProcess.on('error', (err) => {
             disposable.dispose();
+            endPipes();
 
             if (cancellationToken.isCancellationRequested) {
                 reject(new CancellationError('Command cancelled', cancellationToken));
@@ -166,6 +189,10 @@ export async function spawnStreamAsync(
         // Complete the promise when the process exits
         childProcess.on('exit', (code, signal) => {
             disposable.dispose();
+            // NOTE: Do not end the pipes here. The child's stdout/stderr reach EOF when the
+            // process exits, and the `.pipe({ end: true })` wiring ends the destinations after
+            // all output has drained. Ending manually would race that drain and can truncate
+            // trailing output for a slower destination.
 
             if (cancellationToken.isCancellationRequested) {
                 reject(new CancellationError('Command cancelled', cancellationToken));


### PR DESCRIPTION
## Summary

Fixes #540.

`spawnStreamAsync` only ended caller-provided `stdOutPipe`/`stdErrPipe` streams on the **cancellation** path. On a spawn `error` (e.g. `ENOENT` when the executable is not on `PATH`) or a **pre-spawn throw** (already-cancelled token, or Windows executable-resolution failure), the child's stdio streams never deliver EOF to the destination, so a caller awaiting an `AccumulatorStream` (which resolves only on the stream's `finish` event) could hang indefinitely. This was observed in Azure/azure-dev#9136, where an `ENOENT` turned a clean "not found" rejection into an indefinite hang.

## Changes

- Added an idempotent `endPipes()` helper and invoke it on the two paths where the child streams never flow:
  - **pre-spawn throw** — already-cancelled token / executable-resolution failure (wrapped in try/catch so the pipes are ended before rethrowing)
  - **spawn `error`** event (e.g. `ENOENT`)
- **Deliberately do NOT end the pipes on the `exit` path.** The `childProcess.stdout.pipe(dest)` wiring already uses the default `{ end: true }`, so the destination is ended when the source reaches EOF — after a full drain, race-free. This is what makes a non-zero exit settle the accumulator.
- Added an early `return` after the cancellation `reject` in the `error`/`exit` handlers, so a cancelled token no longer falls through to a redundant second settle (avoids tripping Node's `multipleResolves` diagnostics). Addresses Copilot code-review feedback.
- Cancellation behavior is otherwise unchanged.

## Why not end on `exit`?

An earlier iteration also ended pipes in the `exit` handler. Testing with a slow/backpressured destination and a child that writes a large payload then exits non-zero showed the `exit` event fires while stdout is still draining, so a manual `.end()` **truncated the tail** and threw `write after end`. `AccumulatorStream` writes synchronously so it usually drains fast enough to hide this, but any slower caller-provided pipe (file, socket, transform) would lose data. Relying on the pipe's EOF-driven end avoids the race entirely while still ensuring the accumulator settles on non-zero exit.

## Tests

Added `(unit)` regression tests (no Docker required; the default `mocha` run greps `(unit)`), each with timeout-guarded awaits so a re-hang fails deterministically:

- ENOENT spawn error → rejects and accumulators settle
- Non-zero exit → `ChildProcessError` and accumulators settle (stderr captured)
- Pre-spawn cancellation → `CancellationError` and accumulators settle
- **Backpressure guard** → a slow destination receives the full output with no stream error on non-zero exit (fails deterministically on the buggy `end`-on-exit, passes on the fix)

## Verification

- All 10 unit tests pass; lint and build are clean.
- The backpressure regression test fails 3/3 against the buggy `end`-on-exit and passes 3/3 on the fix.

## Changelog

Added a `Fixed` entry under the **1.0.0 - 21 July 2026** release.