### PR TITLE
Fill Compose schema-validation gap when RedHat YAML + Docker DX are both installed

### DIFF
--- a/packages/compose-language-service/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
+++ b/packages/compose-language-service/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
@@ -23,18 +23,19 @@ export class AlternateYamlLanguageServiceClientFeature implements StaticFeature,
     }
 
     private createAlternateYamlLanguageServiceClientCapabilities(): AlternateYamlLanguageServiceClientCapabilities | null {
-        // If Docker's extension is present, we can disable many of the compose language service features
+        // If RedHat YAML's extension or Docker's extension is present, we can disable many of the compose language service features
+        const redhat = vscode.extensions.getExtension('redhat.vscode-yaml') !== undefined;
         const docker = vscode.extensions.getExtension('docker.docker') !== undefined;
-        if (docker) {
+        if (redhat || docker) {
             return {
-                syntaxValidation: docker,
-                schemaValidation: false, // Docker DX does not provide Compose schema validation
-                basicCompletions: docker,
-                advancedCompletions: false, // Docker DX does not have advanced completions for Compose docs
-                hover: docker, // Compose spec has descriptions
+                syntaxValidation: redhat || docker,
+                schemaValidation: redhat && !docker, // RedHat YAML auto-disables its Compose schema detection when Docker DX is present, and Docker DX does not provide Compose schema validation
+                basicCompletions: redhat || docker,
+                advancedCompletions: false, // The other extensions do not have advanced completions for Compose docs
+                hover: redhat || docker, // Compose spec has descriptions
                 imageLinks: false, // Keep Compose image links local so private registries aren't incorrectly linked to Docker Hub (see #179)
-                serviceStartupCodeLens: false, // Docker DX does not provide any code lens
-                formatting: false, // Docker DX does support formatting, but we enable it regardless so that an explicitly-chosen formatter always works
+                serviceStartupCodeLens: false, // The other extensions do not provide any code lens
+                formatting: false, // The other extensions do support formatting, but we enable it regardless so that an explicitly-chosen formatter always works
             };
         }
         return null;

--- a/packages/compose-language-service/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
+++ b/packages/compose-language-service/src/vscode/AlternateYamlLanguageServiceClientFeature.ts
@@ -23,19 +23,18 @@ export class AlternateYamlLanguageServiceClientFeature implements StaticFeature,
     }
 
     private createAlternateYamlLanguageServiceClientCapabilities(): AlternateYamlLanguageServiceClientCapabilities | null {
-        // If RedHat YAML's extension or Docker's extension is present, we can disable many of the compose language service features
-        const redhat = vscode.extensions.getExtension('redhat.vscode-yaml') !== undefined;
+        // If Docker's extension is present, we can disable many of the compose language service features
         const docker = vscode.extensions.getExtension('docker.docker') !== undefined;
-        if (redhat || docker) {
+        if (docker) {
             return {
-                syntaxValidation: redhat || docker,
-                schemaValidation: redhat,
-                basicCompletions: redhat || docker,
-                advancedCompletions: false, // The other extensions do not have advanced completions for Compose docs
-                hover: redhat || docker, // Compose spec has descriptions
+                syntaxValidation: docker,
+                schemaValidation: false, // Docker DX does not provide Compose schema validation
+                basicCompletions: docker,
+                advancedCompletions: false, // Docker DX does not have advanced completions for Compose docs
+                hover: docker, // Compose spec has descriptions
                 imageLinks: false, // Keep Compose image links local so private registries aren't incorrectly linked to Docker Hub (see #179)
-                serviceStartupCodeLens: false, // The other extensions do not provide any code lens
-                formatting: false, // The other extensions do support formatting, but we enable it regardless so that an explicitly-chosen formatter always works
+                serviceStartupCodeLens: false, // Docker DX does not provide any code lens
+                formatting: false, // Docker DX does support formatting, but we enable it regardless so that an explicitly-chosen formatter always works
             };
         }
         return null;


### PR DESCRIPTION
## Summary

RedHat's YAML extension (v1.24.0, released 2026-07-07) now automatically steps back from Compose schema detection when the Docker DX extension (`docker.docker`) is installed — see [`autoDisableSchemaDetection.ts`](https://github.com/redhat-developer/vscode-yaml/blob/main/src/autoDisableSchemaDetection.ts). It still provides syntax validation, hover, and completions for compose files; it just defers schema detection to the more specialized extension when one is present.

Our previous logic deferred *our* Compose schema validation to RedHat whenever RedHat was installed (`schemaValidation: redhat`). But when both RedHat and Docker DX are installed, RedHat defers schema handling to Docker DX, and Docker DX intentionally focuses its diagnostics on YAML syntax rather than JSON-schema validation. The net result was that no one provided Compose schema validation in that combination.

## Change

One line in `AlternateYamlLanguageServiceClientFeature`:

```diff
- schemaValidation: redhat,
+ schemaValidation: redhat && !docker,
```

This keeps our schema validation deferred to RedHat when only RedHat is installed (avoiding duplication), and lets our own schema validation take over when Docker DX is present, so the combination is fully covered.

## Behavior across all combinations

| Installed | Our schema validation | Rationale |
|---|---|---|
| Compose LS only | on | we're the only provider |
| + Docker DX | on | Docker DX focuses on syntax, so we cover schema |
| + RedHat only | off | RedHat provides compose schema |
| + RedHat + Docker DX | on | RedHat defers to Docker DX, so we cover schema |

Syntax validation, completions, and hover continue to be disabled whenever either extension is present (both provide those). Advanced completions, image links, code lens, and formatting are unaffected.

> Known deeper edge case (not handled here): if Docker DX is installed but `docker.extension.enableComposeLanguageServer` is set to `false`, RedHat keeps its schema detection on while Docker DX's compose features are off — extension-presence detection alone can't see that setting.

## Validation

- Build ✅
- Lint ✅ (0 warnings)
- Tests ✅ (128 passing)