### PR TITLE
vscode-inproc-mcp: migrate to MCP server v2.0.0-beta.4

### DIFF
--- a/packages/vscode-inproc-mcp/CHANGELOG.md
+++ b/packages/vscode-inproc-mcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Changed
+* Updated to use `@modelcontextprotocol/server` v2.0.0-beta.4.
+* Switched in-proc HTTP transport wiring to `@modelcontextprotocol/node`'s `NodeStreamableHTTPServerTransport`.
+
 ## 1.0.0 - 21 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.

--- a/packages/vscode-inproc-mcp/CHANGELOG.md
+++ b/packages/vscode-inproc-mcp/CHANGELOG.md
@@ -1,11 +1,8 @@
-## Unreleased
-### Changed
-* Updated to use `@modelcontextprotocol/server` v2.0.0-beta.4.
-* Switched in-proc HTTP transport wiring to `@modelcontextprotocol/node`'s `NodeStreamableHTTPServerTransport`.
-
-## 1.0.0 - 21 July 2026
+## 1.0.0 - 23 July 2026
 ### Changed
 * The repository has been relocated to [microsoft/vscode-containers](https://github.com/microsoft/vscode-containers). The bump to 1.0.0 does not reflect any breaking API changes.
+* Updated to use `@modelcontextprotocol/server` v2.0.0-beta.4.
+* Switched in-proc HTTP transport wiring to `@modelcontextprotocol/node`'s `NodeStreamableHTTPServerTransport`.
 
 ## 0.3.0 - 9 February 2026
 ### Breaking Changes

--- a/packages/vscode-inproc-mcp/package.json
+++ b/packages/vscode-inproc-mcp/package.json
@@ -45,7 +45,7 @@
     "dependencies": {
         "@microsoft/vscode-azext-utils": "catalog:",
         "@microsoft/vscode-processutils": "workspace:*",
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/server": "2.0.0-beta.4",
         "express": "~5",
         "zod": "catalog:"
     },

--- a/packages/vscode-inproc-mcp/package.json
+++ b/packages/vscode-inproc-mcp/package.json
@@ -45,6 +45,7 @@
     "dependencies": {
         "@microsoft/vscode-azext-utils": "catalog:",
         "@microsoft/vscode-processutils": "workspace:*",
+        "@modelcontextprotocol/node": "2.0.0-beta.4",
         "@modelcontextprotocol/server": "2.0.0-beta.4",
         "express": "~5",
         "zod": "catalog:"

--- a/packages/vscode-inproc-mcp/src/mcp/registerMcpTool.ts
+++ b/packages/vscode-inproc-mcp/src/mcp/registerMcpTool.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { McpServer, RegisteredTool, ServerContext, StandardSchemaWithJSON } from '@modelcontextprotocol/server';
 import type { z } from 'zod/mini';
 import type { CopilotTool, ToolIOSchema } from '../contracts/CopilotTool';
 import { McpTool } from './McpTool';
@@ -54,28 +53,53 @@ export function registerMcpTool<TInSchema extends ToolIOSchema, TOutSchema exten
         normalizedOutputSchema = mcpTool.outputSchema;
     }
 
+    const mcpInputSchema = toMcpServerSchema(normalizedInputSchema);
+    const mcpOutputSchema = toMcpServerSchema(normalizedOutputSchema);
+
+    if (mcpInputSchema === undefined) {
+        return server.registerTool(
+            mcpTool.name,
+            {
+                title: mcpTool.title,
+                description: mcpTool.description,
+                outputSchema: mcpOutputSchema,
+                annotations: mcpTool.annotations,
+            },
+            async (extra: ServerContext) => {
+                return mcpTool.executeMcp.call(mcpTool, undefined as z.infer<TInSchema>, toToolExecutionExtras(extra));
+            }
+        );
+    }
+
     return server.registerTool(
         mcpTool.name,
         {
-            ...mcpTool,
-            inputSchema: normalizedInputSchema,
-            outputSchema: normalizedOutputSchema,
+            title: mcpTool.title,
+            description: mcpTool.description,
+            inputSchema: mcpInputSchema,
+            outputSchema: mcpOutputSchema,
+            annotations: mcpTool.annotations,
         },
-        async (input: unknown, extra: RequestHandlerExtra<never, never>) => {
-            // If the input is void, MCP SDK will call with (extra) instead of (undefined, extra)
-            // We won't want that, so detect that case and call appropriately
-            if (inputIsRequestHandlerExtra(input)) {
-                return mcpTool.executeMcp.call(mcpTool, undefined as z.infer<TInSchema>, input);
-            } else {
-                return mcpTool.executeMcp.call(mcpTool, input as z.infer<TInSchema>, extra);
-            }
+        async (input: unknown, extra: ServerContext) => {
+            return mcpTool.executeMcp.call(mcpTool, input as z.infer<TInSchema>, toToolExecutionExtras(extra));
         }
     );
 }
 
-function inputIsRequestHandlerExtra(input: unknown): input is RequestHandlerExtra<never, never> {
-    return !!input &&
-        typeof input === 'object' &&
-        'signal' in input &&
-        input.signal instanceof AbortSignal;
+function toMcpServerSchema(schema: ToolIOSchema | undefined): StandardSchemaWithJSON<unknown, unknown> | undefined {
+    if (!schema) {
+        return undefined;
+    }
+
+    // zod/mini schemas implement the Standard Schema contract expected by @modelcontextprotocol/server,
+    // but the TypeScript package types don't currently line up.
+    return schema as unknown as StandardSchemaWithJSON<unknown, unknown>;
+}
+
+function toToolExecutionExtras(context: ServerContext) {
+    return {
+        signal: context.mcpReq.signal,
+        requestId: context.mcpReq.id,
+        sessionId: context.sessionId,
+    };
 }

--- a/packages/vscode-inproc-mcp/src/vscode/McpProviderOptions.ts
+++ b/packages/vscode-inproc-mcp/src/vscode/McpProviderOptions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type * as vscode from 'vscode';
 
 /**

--- a/packages/vscode-inproc-mcp/src/vscode/inProcHttpServer.ts
+++ b/packages/vscode-inproc-mcp/src/vscode/inProcHttpServer.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { DisposableLike } from '@microsoft/vscode-processutils';
-import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import * as crypto from 'crypto';
 import type * as express from 'express';
 import * as fs from 'fs';
@@ -15,7 +14,12 @@ import { getErrorMessage } from '../utils/getErrorMessage';
 import { Lazy } from '../utils/Lazy';
 import type { McpProviderOptions } from './McpProviderOptions';
 
-const transports: Record<string, StreamableHTTPServerTransport> = {};
+type SessionTransport = {
+    handleRequest: (req: express.Request, res: express.Response, parsedBody?: unknown) => Promise<void>;
+    close: () => Promise<void>;
+};
+
+const transports: Record<string, SessionTransport> = {};
 
 /**
  * Starts a new MCP HTTP server instance on a random named pipe (Windows) or Unix socket (Unix).
@@ -88,19 +92,16 @@ function authMiddleware(nonce: string, req: express.Request, res: express.Respon
 
 async function handlePost(mcpOptions: McpProviderOptions, req: express.Request, res: express.Response): Promise<void> {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    const { isInitializeRequest, McpServer } = await mcpServerModuleLazy.value;
+    const { NodeStreamableHTTPServerTransport } = await mcpNodeModuleLazy.value;
 
-    const isInitializeRequest = await isInitializeRequestLazy.value;
-    const { StreamableHTTPServerTransport } = await streamableHttpLazy.value;
-
-    let transport: StreamableHTTPServerTransport;
+    let transport: SessionTransport;
     if (sessionId && transports[sessionId]) {
         // Existing session
         transport = transports[sessionId];
     } else if (!sessionId && isInitializeRequest(req.body)) {
         // New session initialization request
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore MCP SDK contains a bug where this type mismatches between CJS and ESM, we must ignore it. We also can't do @ts-expect-error because the error only happens when building CJS.
-        transport = new StreamableHTTPServerTransport({
+        transport = new NodeStreamableHTTPServerTransport({
             sessionIdGenerator: () => crypto.randomUUID(),
             onsessioninitialized: (sessionId) => {
                 transports[sessionId] = transport;
@@ -112,7 +113,6 @@ async function handlePost(mcpOptions: McpProviderOptions, req: express.Request, 
             allowedHosts: ['localhost'],
         });
 
-        const { McpServer } = await mcpServerLazy.value;
         const server = new McpServer(
             {
                 name: mcpOptions.id,
@@ -122,9 +122,14 @@ async function handlePost(mcpOptions: McpProviderOptions, req: express.Request, 
         );
 
         try {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore MCP SDK contains a bug where this type mismatches between CJS and ESM, we must ignore it. We also can't do @ts-expect-error because the error only happens when building CJS.
-            await Promise.resolve(mcpOptions.registerTools(server));
+            // ESM and CJS declarations expose nominally distinct McpServer classes.
+            // Both builds share runtime shape, so bridge via the option's parameter type.
+            await Promise.resolve(
+                mcpOptions.registerTools(
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                    server as unknown as Parameters<McpProviderOptions['registerTools']>[0]
+                )
+            );
         } catch (err) {
             // Failed to register tools, return error
             res.status(500).json({
@@ -138,7 +143,7 @@ async function handlePost(mcpOptions: McpProviderOptions, req: express.Request, 
             return;
         }
 
-        await server.connect(transport);
+        await server.connect(transport as unknown as Parameters<typeof server.connect>[0]);
     } else {
         // Invalid request
         res.status(400).json({
@@ -206,9 +211,5 @@ function tryCleanupSocket(socketPath: string | undefined): void {
 
 // Lazily load some modules that are only needed when an MCP server is actually started
 const expressLazy = new Lazy(async () => await import('express'));
-const streamableHttpLazy = new Lazy(async () => await import('@modelcontextprotocol/sdk/server/streamableHttp.js'));
-const mcpServerLazy = new Lazy(async () => await import('@modelcontextprotocol/sdk/server/mcp.js'));
-const isInitializeRequestLazy = new Lazy(async () => {
-    const { isInitializeRequest } = await import('@modelcontextprotocol/sdk/types.js');
-    return isInitializeRequest;
-});
+const mcpServerModuleLazy = new Lazy(async () => await import('@modelcontextprotocol/server'));
+const mcpNodeModuleLazy = new Lazy(async () => await import('@modelcontextprotocol/node'));

--- a/packages/vscode-inproc-mcp/src/vscode/registerMcpToolWithTelemetry.ts
+++ b/packages/vscode-inproc-mcp/src/vscode/registerMcpToolWithTelemetry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { CopilotTool, ToolIOSchema } from '../contracts/CopilotTool';
 import { registerMcpTool } from '../mcp/registerMcpTool';
 import { McpToolWithTelemetry } from './McpToolWithTelemetry';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@microsoft/vscode-processutils':
         specifier: workspace:*
         version: link:../vscode-processutils
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4(@modelcontextprotocol/server@2.0.0-beta.4)(hono@4.12.30)
       '@modelcontextprotocol/server':
         specifier: 2.0.0-beta.4
         version: 2.0.0-beta.4
@@ -572,6 +575,12 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -705,6 +714,16 @@ packages:
   '@modelcontextprotocol/core@2.0.0-beta.4':
     resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0-beta.4':
+    resolution: {integrity: sha512-OqbrRVNYNfLxBB2BRkP5oIHKHa0IPHluMbaLgw7YCRKcj5be9ExzyWFJY3KVMb+1F2AVn+0SRoH0XKcNzh3HYQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0-beta.4
+      hono: ^4.11.4
+    peerDependenciesMeta:
+      hono:
+        optional: true
 
   '@modelcontextprotocol/server@2.0.0-beta.4':
     resolution: {integrity: sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==}
@@ -1815,6 +1834,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -3338,6 +3361,10 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3532,6 +3559,13 @@ snapshots:
   '@modelcontextprotocol/core@2.0.0-beta.4':
     dependencies:
       zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0-beta.4(@modelcontextprotocol/server@2.0.0-beta.4)(hono@4.12.30)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      '@modelcontextprotocol/server': 2.0.0-beta.4
+    optionalDependencies:
+      hono: 4.12.30
 
   '@modelcontextprotocol/server@2.0.0-beta.4':
     dependencies:
@@ -4799,6 +4833,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  hono@4.12.30: {}
 
   hosted-git-info@4.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,9 @@ importers:
       '@microsoft/vscode-processutils':
         specifier: workspace:*
         version: link:../vscode-processutils
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.26.0
-        version: 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4
       express:
         specifier: ~5
         version: 5.2.1
@@ -572,12 +572,6 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -708,15 +702,13 @@ packages:
   '@microsoft/vscode-processutils@0.2.2':
     resolution: {integrity: sha512-kvADRfnSAUcusBzBAn0eDsh880MjTw1tvYGUes6yxUBALkg7RiQPuy2p3gDR4+p+VZqb2T2youY4jgq3/6jnKw==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
+  '@modelcontextprotocol/core@2.0.0-beta.4':
+    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0-beta.4':
+    resolution: {integrity: sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==}
+    engines: {node: '>=20'}
 
   '@nevware21/ts-async@0.5.5':
     resolution: {integrity: sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==}
@@ -1157,14 +1149,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1402,10 +1386,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1651,23 +1631,9 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
-
-  express-rate-limit@8.5.2:
-    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -1850,10 +1816,6 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hono@4.12.29:
-    resolution: {integrity: sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -1922,10 +1884,6 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2024,9 +1982,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2042,9 +1997,6 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2277,10 +2229,6 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2396,10 +2344,6 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
-
-  pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -2993,11 +2937,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3399,10 +3338,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.29)':
-    dependencies:
-      hono: 4.12.29
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3594,27 +3529,14 @@ snapshots:
       tree-kill: 1.2.2
       which: 5.0.0
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/core@2.0.0-beta.4':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
+
+  '@modelcontextprotocol/server@2.0.0-beta.4':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.4
+      zod: 4.4.3
 
   '@nevware21/ts-async@0.5.5':
     dependencies:
@@ -4115,10 +4037,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4362,11 +4280,6 @@ snapshots:
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4646,19 +4559,8 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.1.0: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.1.0
-
   expand-template@2.0.3:
     optional: true
-
-  express-rate-limit@8.5.2(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -4898,8 +4800,6 @@ snapshots:
 
   he@1.2.0: {}
 
-  hono@4.12.29: {}
-
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -4980,8 +4880,6 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ip-address@10.2.0: {}
-
   ipaddr.js@1.9.1: {}
 
   is-binary-path@2.1.0:
@@ -5055,8 +4953,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jose@6.2.3: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.0:
@@ -5068,8 +4964,6 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5311,8 +5205,6 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  object-assign@4.1.1: {}
-
   object-inspect@1.13.4: {}
 
   on-finished@2.4.1:
@@ -5430,8 +5322,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
-
-  pkce-challenge@5.0.1: {}
 
   pluralize@2.0.0: {}
 
@@ -6077,9 +5967,5 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yocto-queue@0.1.0: {}
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- migrate `@microsoft/vscode-inproc-mcp` from `@modelcontextprotocol/sdk` to `@modelcontextprotocol/server@2.0.0-beta.4`
- update MCP imports and tool registration wiring for v2 server/context/schema typing
- map MCP v2 `ServerContext` to existing tool execution extras in `registerMcpTool`
- refactor in-proc HTTP transport to use `@modelcontextprotocol/node` `NodeStreamableHTTPServerTransport` instead of custom Express↔Web request/response bridging
- update changelog and lockfile

## Why
`@modelcontextprotocol/server` v2 is the current split package and has API/type differences from the legacy monolithic SDK. This PR adapts `vscode-inproc-mcp` to the new server package while keeping existing behavior for session lifecycle and provider registration.

## Validation
Ran for `@microsoft/vscode-inproc-mcp`:
- `pnpm --filter @microsoft/vscode-inproc-mcp run lint`
- `pnpm --filter @microsoft/vscode-inproc-mcp run build`
- `pnpm --filter @microsoft/vscode-inproc-mcp run test`