### PR TITLE
Bump @hono/node-server to version 2.0.10

### DIFF
--- a/packages/vscode-inproc-mcp/package.json
+++ b/packages/vscode-inproc-mcp/package.json
@@ -43,7 +43,7 @@
         "vscode": "^1.105.0"
     },
     "dependencies": {
-        "@hono/node-server": "^1.19.14",
+        "@hono/node-server": "^2.0.10",
         "@microsoft/vscode-azext-utils": "catalog:",
         "@microsoft/vscode-processutils": "workspace:*",
         "@modelcontextprotocol/server": "2.0.0-beta.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
   packages/vscode-inproc-mcp:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.30)
+        specifier: ^2.0.10
+        version: 2.0.10(hono@4.12.30)
       '@microsoft/vscode-azext-utils':
         specifier: 'catalog:'
         version: 4.1.1(@azure/ms-rest-azure-env@2.0.0)(tslib@2.8.1)
@@ -571,9 +571,9 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -3165,7 +3165,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.30)':
+  '@hono/node-server@2.0.10(hono@4.12.30)':
     dependencies:
       hono: 4.12.30
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1576,8 +1576,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-xml-builder@1.2.1:
     resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
@@ -3836,7 +3836,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4329,7 +4329,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-xml-builder@1.2.1:
     dependencies:


### PR DESCRIPTION
This pull request updates the `@hono/node-server` dependency to version 2.0.10 in the `vscode-inproc-mcp` package. The changes include:

- Updated `package.json` to reflect the new version of `@hono/node-server`.
- Updated `pnpm-lock.yaml` to synchronize the lockfile with the new dependency version.

The update was confirmed to be compatible with the current Node.js version (22.18) used in the repository, and all relevant build and test commands have passed successfully. The `NOTICE.html` file has been reverted to its original state as per the request.