### PR TITLE
Support debugging single-file .NET apps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot / agent instructions for vscode-containers
+
+Guidance for AI coding agents working in this repository.
+
+## Curated files — do not auto-edit
+
+Some files are curated by maintainers and must not be edited as a side effect of a
+code change. Do not add, reword, or reorder entries in them unless the task is
+explicitly about updating that file.
+
+- **`extensions/vscode-containers/CHANGELOG.md`** — The changelog is hand-curated by
+  maintainers as part of the release process. Do **not** add a changelog entry when
+  implementing a feature or fix; leave it untouched.
+- **`extensions/vscode-docker/CHANGELOG.md`** — Same as above.
+- **`NOTICE.html`** — A generated, curated artifact; never hand-edit it.
+
+## Reviewing pull requests
+
+This repository ships its own review skills under `.github/skills/`. When asked to
+review a PR (or when performing an automated review), use them and follow the shared
+grading rubric rather than reviewing ad hoc:
+
+- **`code-review`** (`.github/skills/code-review/SKILL.md`) — For the automated review
+  context where the PR diff and changed files are already provided. Works from the given
+  diff; does not fetch the PR or run `gh`.
+- **`review-pr`** (`.github/skills/review-pr/SKILL.md`) — For on-demand reviews of a PR by
+  number, URL, or "the current branch". Fetches the PR with the GitHub CLI and, only when
+  explicitly asked, posts comments.
+- **`.github/skills/code-review/rubric.md`** — The shared grading rubric both skills apply.
+  It is the single source of truth for what to look for and how to grade a change. Never
+  approve a PR — approval is a human maintainer's decision.

--- a/extensions/vscode-containers/src/constants.ts
+++ b/extensions/vscode-containers/src/constants.ts
@@ -25,6 +25,7 @@ export const YAML_GLOB_PATTERN = '**/*.{[yY][aA][mM][lL],[yY][mM][lL]}';
 export const CSPROJ_GLOB_PATTERN = '**/*.{[cC][sS][pP][rR][oO][jJ]}';
 export const FSPROJ_GLOB_PATTERN = '**/*.{[fF][sS][pP][rR][oO][jJ]}';
 export const VBPROJ_GLOB_PATTERN = '**/*.{[vV][bB][pP][rR][oO][jJ]}';
+export const CS_GLOB_PATTERN = '**/*.{[cC][sS]}'; // Used to detect file-based .NET apps (single .cs file run via `dotnet run app.cs`)
 
 // File search max ammout
 export const FILE_SEARCH_MAX_RESULT = 1000;

--- a/extensions/vscode-containers/src/constants.ts
+++ b/extensions/vscode-containers/src/constants.ts
@@ -26,6 +26,8 @@ export const CSPROJ_GLOB_PATTERN = '**/*.{[cC][sS][pP][rR][oO][jJ]}';
 export const FSPROJ_GLOB_PATTERN = '**/*.{[fF][sS][pP][rR][oO][jJ]}';
 export const VBPROJ_GLOB_PATTERN = '**/*.{[vV][bB][pP][rR][oO][jJ]}';
 export const CS_GLOB_PATTERN = '**/*.{[cC][sS]}'; // Used to detect file-based .NET apps (single .cs file run via `dotnet run app.cs`)
+// Excludes .NET build output folders (bin/obj), which contain generated .cs files (e.g. *.AssemblyInfo.cs, *.GlobalUsings.g.cs)
+export const NET_BUILD_OUTPUT_EXCLUDE_PATTERN = '**/{[bB][iI][nN],[oO][bB][jJ]}/**';
 
 // File search max ammout
 export const FILE_SEARCH_MAX_RESULT = 1000;

--- a/extensions/vscode-containers/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/extensions/vscode-containers/src/debugging/DockerDebugConfigurationProvider.ts
@@ -5,9 +5,10 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext, registerEvent, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { CancellationToken, commands, debug, DebugConfiguration, DebugConfigurationProvider, DebugSession, l10n, ProviderResult, workspace, WorkspaceFolder } from 'vscode';
-import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DockerOrchestration, FSPROJ_GLOB_PATTERN } from '../constants';
+import { CSPROJ_GLOB_PATTERN, DockerOrchestration, FSPROJ_GLOB_PATTERN } from '../constants';
 import { ext } from '../extensionVariables';
 import { getAssociatedDockerRunTask } from '../tasks/TaskHelper';
+import { isFileBasedAppFolder } from '../utils/netCoreUtils';
 import { resolveFilesOfPattern } from '../utils/quickPickFile';
 import { DebugHelper, DockerDebugContext, ResolvedDebugConfiguration } from './DebugHelper';
 import { DockerPlatform, getDebugPlatform } from './DockerDebugPlatformHelper';
@@ -198,8 +199,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         // check if it's a .NET project (project-based .csproj/.fsproj or a file-based app: a single .cs file)
         const csProjUris = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
-        const fileBasedAppUris = csProjUris ? undefined : await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
-        if (csProjUris || fileBasedAppUris) {
+        if (csProjUris || await isFileBasedAppFolder(folder)) {
             return await netSdkDebugHelper.provideDebugConfigurations(
                 {
                     actionContext,

--- a/extensions/vscode-containers/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/extensions/vscode-containers/src/debugging/DockerDebugConfigurationProvider.ts
@@ -5,7 +5,7 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext, registerEvent, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { CancellationToken, commands, debug, DebugConfiguration, DebugConfigurationProvider, DebugSession, l10n, ProviderResult, workspace, WorkspaceFolder } from 'vscode';
-import { CSPROJ_GLOB_PATTERN, DockerOrchestration, FSPROJ_GLOB_PATTERN } from '../constants';
+import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DockerOrchestration, FSPROJ_GLOB_PATTERN } from '../constants';
 import { ext } from '../extensionVariables';
 import { getAssociatedDockerRunTask } from '../tasks/TaskHelper';
 import { resolveFilesOfPattern } from '../utils/quickPickFile';
@@ -196,9 +196,10 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         // NOTE: We can not determine the language from `DockerDebugContext`, so we need to check the
         //       type of files inside the folder here to determine the language.
 
-        // check if it's a .NET Core project
+        // check if it's a .NET project (project-based .csproj/.fsproj or a file-based app: a single .cs file)
         const csProjUris = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
-        if (csProjUris) {
+        const fileBasedAppUris = csProjUris ? undefined : await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
+        if (csProjUris || fileBasedAppUris) {
             return await netSdkDebugHelper.provideDebugConfigurations(
                 {
                     actionContext,

--- a/extensions/vscode-containers/src/debugging/netSdk/NetSdkDebugHelper.ts
+++ b/extensions/vscode-containers/src/debugging/netSdk/NetSdkDebugHelper.ts
@@ -6,18 +6,16 @@
 import { composeArgs, withNamedArg } from "@microsoft/vscode-processutils";
 import * as path from "path";
 import { WorkspaceFolder, commands, l10n, tasks } from "vscode";
-import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { NetChooseBuildTypeContext, netContainerBuild } from "../../scaffolding/wizard/net/NetContainerBuild";
 import { AllNetContainerBuildOptions, NetContainerBuildOptionsKey } from "../../scaffolding/wizard/net/NetSdkChooseBuildStep";
 import { NetSdkRunTaskDefinition, netSdkRunTaskProvider } from "../../tasks/netSdk/NetSdkRunTaskProvider";
 import { normalizeArchitectureToRidArchitecture, normalizeOsToRidOs } from "../../tasks/netSdk/netSdkTaskUtils";
 import { NetCoreTaskHelper } from "../../tasks/netcore/NetCoreTaskHelper";
-import { getNetCoreProjectInfo, isFileBasedApp } from "../../utils/netCoreUtils";
+import { getNetCoreProjectInfo, isFileBasedApp, isFileBasedAppFolder } from "../../utils/netCoreUtils";
 import { getDockerOSType } from "../../utils/osUtils";
 import { PlatformOS } from "../../utils/platform";
 import { resolveVariables, unresolveWorkspaceFolder } from "../../utils/resolveVariables";
-import { resolveFilesOfPattern } from "../../utils/quickPickFile";
 import { DockerDebugContext, DockerDebugScaffoldContext, ResolvedDebugConfiguration, inferContainerName } from "../DebugHelper";
 import { DockerDebugConfiguration } from "../DockerDebugConfigurationProvider";
 import { NetCoreDebugHelper, NetCoreDebugScaffoldingOptions, NetCoreProjectProperties } from "../netcore/NetCoreDebugHelper";
@@ -39,7 +37,7 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
             workspaceFolder: context.folder,
             // File-based apps (a single .cs file with no .csproj/.fsproj) can only be built with the .NET SDK,
             // so we skip the "SDK vs Dockerfile" prompt for them.
-            isFileBasedApp: await NetSdkDebugHelper.isFileBasedAppFolder(context.folder),
+            isFileBasedApp: await isFileBasedAppFolder(context.folder),
         };
 
         await netContainerBuild(netCoreBuildContext); // prompt user whether to use .NET container SDK build
@@ -148,20 +146,6 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
         } else {
             throw new Error(l10n.t("Your current project configuration or .NET SDK version doesn't support SDK Container build. Please choose a compatible project or update .NET SDK."));
         }
-    }
-
-    /**
-     * Determines whether the folder is a file-based .NET app: it contains a single-file app (.cs) and no
-     * project file (.csproj/.fsproj), meaning the .NET SDK is the only way to build a container image for it.
-     */
-    private static async isFileBasedAppFolder(folder: WorkspaceFolder): Promise<boolean> {
-        const projectFiles = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
-        if (projectFiles) {
-            return false;
-        }
-
-        const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
-        return !!fileBasedApps;
     }
 }
 

--- a/extensions/vscode-containers/src/debugging/netSdk/NetSdkDebugHelper.ts
+++ b/extensions/vscode-containers/src/debugging/netSdk/NetSdkDebugHelper.ts
@@ -6,16 +6,18 @@
 import { composeArgs, withNamedArg } from "@microsoft/vscode-processutils";
 import * as path from "path";
 import { WorkspaceFolder, commands, l10n, tasks } from "vscode";
+import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { NetChooseBuildTypeContext, netContainerBuild } from "../../scaffolding/wizard/net/NetContainerBuild";
 import { AllNetContainerBuildOptions, NetContainerBuildOptionsKey } from "../../scaffolding/wizard/net/NetSdkChooseBuildStep";
 import { NetSdkRunTaskDefinition, netSdkRunTaskProvider } from "../../tasks/netSdk/NetSdkRunTaskProvider";
 import { normalizeArchitectureToRidArchitecture, normalizeOsToRidOs } from "../../tasks/netSdk/netSdkTaskUtils";
 import { NetCoreTaskHelper } from "../../tasks/netcore/NetCoreTaskHelper";
-import { getNetCoreProjectInfo } from "../../utils/netCoreUtils";
+import { getNetCoreProjectInfo, isFileBasedApp } from "../../utils/netCoreUtils";
 import { getDockerOSType } from "../../utils/osUtils";
 import { PlatformOS } from "../../utils/platform";
 import { resolveVariables, unresolveWorkspaceFolder } from "../../utils/resolveVariables";
+import { resolveFilesOfPattern } from "../../utils/quickPickFile";
 import { DockerDebugContext, DockerDebugScaffoldContext, ResolvedDebugConfiguration, inferContainerName } from "../DebugHelper";
 import { DockerDebugConfiguration } from "../DockerDebugConfigurationProvider";
 import { NetCoreDebugHelper, NetCoreDebugScaffoldingOptions, NetCoreProjectProperties } from "../netcore/NetCoreDebugHelper";
@@ -35,6 +37,9 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
             ...context.actionContext,
             scaffoldType: 'debugging',
             workspaceFolder: context.folder,
+            // File-based apps (a single .cs file with no .csproj/.fsproj) can only be built with the .NET SDK,
+            // so we skip the "SDK vs Dockerfile" prompt for them.
+            isFileBasedApp: await NetSdkDebugHelper.isFileBasedAppFolder(context.folder),
         };
 
         await netContainerBuild(netCoreBuildContext); // prompt user whether to use .NET container SDK build
@@ -110,10 +115,14 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
     protected override async getProjectProperties(debugConfiguration: DockerDebugConfiguration, folder?: WorkspaceFolder): Promise<NetSdkProjectProperties> {
         const ridOS = await normalizeOsToRidOs();
         const ridArchitecture = await normalizeArchitectureToRidArchitecture();
+        const resolvedAppProject = resolveVariables(debugConfiguration.netCore?.appProject, folder);
+        // File-based apps default to PublishAot, which changes the computed container configuration. Disable it
+        // so the properties match the debuggable (managed) image we build.
+        const publishAot = isFileBasedApp(resolvedAppProject) ? 'false' : undefined;
         const additionalProperties = composeArgs(
             withNamedArg('-p:ContainerRuntimeIdentifier', `"${ridOS}-${ridArchitecture}"`, { assignValue: true }), // We have to pre-quote the RID because we cannot simultaneously use `assignValue` and `shouldQuote`
+            withNamedArg('-p:PublishAot', publishAot, { assignValue: true }),
         )();
-        const resolvedAppProject = resolveVariables(debugConfiguration.netCore?.appProject, folder);
 
         const projectInfo = await getNetCoreProjectInfo(resolvedAppProject, additionalProperties);
 
@@ -139,6 +148,20 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
         } else {
             throw new Error(l10n.t("Your current project configuration or .NET SDK version doesn't support SDK Container build. Please choose a compatible project or update .NET SDK."));
         }
+    }
+
+    /**
+     * Determines whether the folder is a file-based .NET app: it contains a single-file app (.cs) and no
+     * project file (.csproj/.fsproj), meaning the .NET SDK is the only way to build a container image for it.
+     */
+    private static async isFileBasedAppFolder(folder: WorkspaceFolder): Promise<boolean> {
+        const projectFiles = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
+        if (projectFiles) {
+            return false;
+        }
+
+        const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
+        return !!fileBasedApps;
     }
 }
 

--- a/extensions/vscode-containers/src/scaffolding/wizard/net/NetContainerBuild.ts
+++ b/extensions/vscode-containers/src/scaffolding/wizard/net/NetContainerBuild.ts
@@ -10,6 +10,8 @@ import { NetContainerBuildOption, NetSdkChooseBuildStep } from './NetSdkChooseBu
 
 export interface NetChooseBuildTypeContext extends ScaffoldingWizardContext {
     containerBuildOption?: NetContainerBuildOption;
+    // File-based apps (a single .cs file) can only be built with the .NET SDK, so the build-type prompt is skipped for them.
+    isFileBasedApp?: boolean;
 }
 
 export async function netContainerBuild(wizardContext: Partial<NetChooseBuildTypeContext>, apiInput?: NetChooseBuildTypeContext): Promise<void> {

--- a/extensions/vscode-containers/src/scaffolding/wizard/net/NetSdkChooseBuildStep.ts
+++ b/extensions/vscode-containers/src/scaffolding/wizard/net/NetSdkChooseBuildStep.ts
@@ -25,6 +25,12 @@ export class NetSdkChooseBuildStep extends TelemetryPromptStep<NetChooseBuildTyp
     public async prompt(wizardContext: NetChooseBuildTypeContext): Promise<void> {
         await this.ensureCSharpExtension(wizardContext);
 
+        // File-based apps (a single .cs file) have no Dockerfile flow, so force the .NET SDK build without prompting.
+        if (wizardContext.isFileBasedApp) {
+            wizardContext.containerBuildOption = AllNetContainerBuildOptions[1];
+            return;
+        }
+
         // get workspace momento storage
         const containerBuildOption = await ext.context.workspaceState.get<NetContainerBuildOption>(NetContainerBuildOptionsKey);
 

--- a/extensions/vscode-containers/src/tasks/netSdk/NetSdkRunTaskProvider.ts
+++ b/extensions/vscode-containers/src/tasks/netSdk/NetSdkRunTaskProvider.ts
@@ -29,7 +29,7 @@ export class NetSdkRunTaskProvider extends DockerTaskProvider {
         const projectFolderPath = path.dirname(projectPath);
 
         // use dotnet to build the image
-        const { command: buildCommand, args: buildArgs } = await getNetSdkBuildCommand();
+        const { command: buildCommand, args: buildArgs } = await getNetSdkBuildCommand(projectPath);
         await context.terminal.execAsyncInTerminal(
             buildCommand,
             buildArgs,

--- a/extensions/vscode-containers/src/tasks/netSdk/netSdkTaskUtils.ts
+++ b/extensions/vscode-containers/src/tasks/netSdk/netSdkTaskUtils.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DockerClient, PodmanClient, RunContainerBindMount, RunContainerCommandOptions } from "@microsoft/vscode-container-client";
-import { CommandLineArgs, composeArgs, withArg, withNamedArg } from '@microsoft/vscode-processutils';
+import { CommandLineArgs, composeArgs, withArg, withNamedArg, withQuotedArg } from '@microsoft/vscode-processutils';
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { configPrefix } from "../../constants";
 import { vsDbgInstallBasePath } from "../../debugging/netcore/VsDbgHelper";
 import { ext } from "../../extensionVariables";
 import { getImageNameWithTag } from "../../utils/getValidImageName";
+import { isFileBasedApp } from "../../utils/netCoreUtils";
 import { getDockerOSType } from "../../utils/osUtils";
 import { defaultVsCodeLabels } from "../TaskDefinitionBase";
 import { getDefaultContainerName } from '../TaskHelper';
@@ -32,15 +33,23 @@ export type RidCpuArchitecture =
 export const NetSdkRunTaskType = 'dotnet-container-sdk';
 const NetSdkDefaultImageTag = 'dev'; // intentionally default to dev tag for phase 1 of this feature
 
-export async function getNetSdkBuildCommand(): Promise<{ command: string, args: CommandLineArgs }> {
+export async function getNetSdkBuildCommand(projectPath?: string): Promise<{ command: string, args: CommandLineArgs }> {
+    // File-based apps enable PublishAot by default, which produces a native executable instead of a
+    // managed .dll. Disable it so we get a debuggable image that runs the app with `dotnet`.
+    const publishAot = isFileBasedApp(projectPath) ? 'false' : undefined;
+
     const args = composeArgs(
         withArg('publish'),
+        withNamedArg('-p:PublishAot', publishAot, { assignValue: true }),
         withNamedArg('--os', await normalizeOsToRidOs()),
         withNamedArg('--arch', await normalizeArchitectureToRidArchitecture()),
         withArg('/t:PublishContainer'),
         withNamedArg('--configuration', 'Debug'),
         withNamedArg('-p:ContainerImageTag', NetSdkDefaultImageTag, { assignValue: true }),
         withNamedArg('-p:LocalRegistry', getLocalRegistry(), { assignValue: true }),
+        // The project/file is passed last. It is required for file-based apps (there is no .csproj in the
+        // folder for `dotnet publish` to discover) and is harmless for project-based apps.
+        withQuotedArg(projectPath),
     )();
 
     return { command: 'dotnet', args: args };

--- a/extensions/vscode-containers/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/extensions/vscode-containers/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -16,6 +16,7 @@ import { vsDbgInstallBasePath } from '../../debugging/netcore/VsDbgHelper';
 import { ext } from '../../extensionVariables';
 import { PlatformOS } from '../../utils/platform';
 import { quickPickProjectFileItem } from '../../utils/quickPickFile';
+import { isFileBasedApp } from '../../utils/netCoreUtils';
 import { resolveVariables, unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { DockerBuildOptions, DockerBuildTaskDefinitionBase } from '../DockerBuildTaskDefinitionBase';
 import { DockerBuildTaskDefinition } from '../DockerBuildTaskProvider';
@@ -176,8 +177,8 @@ export class NetCoreTaskHelper implements TaskHelper {
         if (helperOptions && helperOptions.appProject) {
             result = resolveVariables(helperOptions.appProject, context.folder);
         } else {
-            // Find a .csproj or .fsproj in the folder
-            const item = await quickPickProjectFileItem(context.actionContext, undefined, context.folder, l10n.t('No .NET project file (.csproj or .fsproj) could be found.'));
+            // Find a .csproj or .fsproj in the folder, falling back to a file-based app (single .cs file) if none is found
+            const item = await quickPickProjectFileItem(context.actionContext, undefined, context.folder, l10n.t('No .NET project file (.csproj or .fsproj) or file-based app (.cs) could be found.'), true);
             result = item.absoluteFilePath;
         }
 
@@ -185,9 +186,14 @@ export class NetCoreTaskHelper implements TaskHelper {
     }
 
     public static async isWebApp(appProject: string): Promise<boolean> {
-        const projectContents = await fse.readFile(appProject);
+        const projectContents = (await fse.readFile(appProject)).toString();
 
-        return /Sdk\s*=\s*"Microsoft\.NET\.Sdk\.Web"/ig.test(projectContents.toString());
+        if (isFileBasedApp(appProject)) {
+            // File-based apps declare the SDK with a `#:sdk Microsoft.NET.Sdk.Web` directive instead of a project-level Sdk attribute
+            return /^\s*#:sdk\s+Microsoft\.NET\.Sdk\.Web\b/im.test(projectContents);
+        }
+
+        return /Sdk\s*=\s*"Microsoft\.NET\.Sdk\.Web"/ig.test(projectContents);
     }
 
     private async inferUserSecrets(helperOptions: NetCoreTaskOptions): Promise<boolean> {

--- a/extensions/vscode-containers/src/utils/netCoreUtils.ts
+++ b/extensions/vscode-containers/src/utils/netCoreUtils.ts
@@ -4,11 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parseError } from '@microsoft/vscode-azext-utils';
-import { CommandLineArgs, composeArgs, withArg, withQuotedArg } from '@microsoft/vscode-processutils';
+import { CommandLineArgs, composeArgs, withArg, withFlagArg, withQuotedArg } from '@microsoft/vscode-processutils';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as z from 'zod/mini';
 import { execAsync } from './execAsync';
+
+/**
+ * Determines whether the given .NET "project" is actually a file-based app: a single C# file
+ * (e.g. `app.cs`) that can be run directly with `dotnet run app.cs` without a `.csproj`.
+ * {@link https://devblogs.microsoft.com/dotnet/announcing-dotnet-run-app/}
+ */
+export function isFileBasedApp(project: string | undefined): boolean {
+    return !!project && path.extname(project).toLowerCase() === '.cs';
+}
 
 interface NetCoreCommonProjectInfo {
     assemblyName: string;
@@ -49,7 +58,9 @@ const RawNetCoreProjectInfoSchema = z.object({
 
 export async function getNetCoreProjectInfo(project: string, additionalProperties?: CommandLineArgs): Promise<NetCoreProjectInfo> {
     const args = composeArgs(
-        withArg('build', '--no-restore'),
+        withArg('build'),
+        // File-based apps (single .cs file) have no prior restore, so we must allow the implicit restore.
+        withFlagArg('--no-restore', !isFileBasedApp(project)),
         withArg('-target:ComputeContainerConfig'),
         withArg('-getProperty:AssemblyName,TargetFramework,TargetFrameworks,OutputPath,EnableSdkContainerSupport,ContainerWorkingDirectory,ContainerRepository'),
         withArg(...(additionalProperties ?? [])),

--- a/extensions/vscode-containers/src/utils/netCoreUtils.ts
+++ b/extensions/vscode-containers/src/utils/netCoreUtils.ts
@@ -8,7 +8,7 @@ import { CommandLineArgs, composeArgs, withArg, withFlagArg, withQuotedArg } fro
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as z from 'zod/mini';
-import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from '../constants';
+import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN, NET_BUILD_OUTPUT_EXCLUDE_PATTERN } from '../constants';
 import { execAsync } from './execAsync';
 import { resolveFilesOfPattern } from './quickPickFile';
 
@@ -32,7 +32,8 @@ export async function isFileBasedAppFolder(folder: vscode.WorkspaceFolder): Prom
         return false;
     }
 
-    const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN], undefined, 1);
+    // Exclude bin/obj so generated .cs files (e.g. *.AssemblyInfo.cs) don't get mistaken for a file-based app.
+    const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN], NET_BUILD_OUTPUT_EXCLUDE_PATTERN, 1);
     return !!(fileBasedApps?.length);
 }
 

--- a/extensions/vscode-containers/src/utils/netCoreUtils.ts
+++ b/extensions/vscode-containers/src/utils/netCoreUtils.ts
@@ -8,7 +8,9 @@ import { CommandLineArgs, composeArgs, withArg, withFlagArg, withQuotedArg } fro
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as z from 'zod/mini';
+import { CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from '../constants';
 import { execAsync } from './execAsync';
+import { resolveFilesOfPattern } from './quickPickFile';
 
 /**
  * Determines whether the given .NET "project" is actually a file-based app: a single C# file
@@ -17,6 +19,20 @@ import { execAsync } from './execAsync';
  */
 export function isFileBasedApp(project: string | undefined): boolean {
     return !!project && path.extname(project).toLowerCase() === '.cs';
+}
+
+/**
+ * Determines whether the folder is a file-based .NET app: it contains a single-file app (.cs) and no
+ * project file (.csproj/.fsproj), meaning the .NET SDK is the only way to build a container image for it.
+ */
+export async function isFileBasedAppFolder(folder: vscode.WorkspaceFolder): Promise<boolean> {
+    const projectFiles = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
+    if (projectFiles?.length) {
+        return false;
+    }
+
+    const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
+    return !!(fileBasedApps?.length);
 }
 
 interface NetCoreCommonProjectInfo {

--- a/extensions/vscode-containers/src/utils/netCoreUtils.ts
+++ b/extensions/vscode-containers/src/utils/netCoreUtils.ts
@@ -26,12 +26,13 @@ export function isFileBasedApp(project: string | undefined): boolean {
  * project file (.csproj/.fsproj), meaning the .NET SDK is the only way to build a container image for it.
  */
 export async function isFileBasedAppFolder(folder: vscode.WorkspaceFolder): Promise<boolean> {
-    const projectFiles = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
+    // We only need to know whether any matching file exists, so cap the search at a single result.
+    const projectFiles = await resolveFilesOfPattern(folder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN], undefined, 1);
     if (projectFiles?.length) {
         return false;
     }
 
-    const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN]);
+    const fileBasedApps = await resolveFilesOfPattern(folder, [CS_GLOB_PATTERN], undefined, 1);
     return !!(fileBasedApps?.length);
 }
 

--- a/extensions/vscode-containers/src/utils/quickPickFile.ts
+++ b/extensions/vscode-containers/src/utils/quickPickFile.ts
@@ -6,7 +6,7 @@
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from "path";
 import * as vscode from 'vscode';
-import { COMPOSE_FILE_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
+import { COMPOSE_FILE_GLOB_PATTERN, CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
 
 export interface Item extends vscode.QuickPickItem {
     relativeFilePath: string;
@@ -165,12 +165,18 @@ export async function quickPickYamlFileItem(context: IActionContext, fileUri: vs
     return fileItem;
 }
 
-export async function quickPickProjectFileItem(context: IActionContext, fileUri: vscode.Uri, rootFolder: vscode.WorkspaceFolder, noProjectFileMessage: string): Promise<Item> {
+export async function quickPickProjectFileItem(context: IActionContext, fileUri: vscode.Uri, rootFolder: vscode.WorkspaceFolder, noProjectFileMessage: string, includeFileBasedApps?: boolean): Promise<Item> {
     if (fileUri) {
         return createFileItem(rootFolder, fileUri);
     }
 
-    const items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
+    let items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
+
+    // If there are no project files and file-based apps are allowed, fall back to offering the .cs files in the workspace
+    if (!items && includeFileBasedApps) {
+        items = await resolveFilesOfPattern(rootFolder, [CS_GLOB_PATTERN]);
+    }
+
     const fileItem: Item = await quickPickFileItem(context, items, vscode.l10n.t('Choose a project file.'));
 
     if (!fileItem) {

--- a/extensions/vscode-containers/src/utils/quickPickFile.ts
+++ b/extensions/vscode-containers/src/utils/quickPickFile.ts
@@ -15,8 +15,8 @@ export interface Item extends vscode.QuickPickItem {
     absoluteFolderPath: string;
 }
 
-async function getFileUris(folder: vscode.WorkspaceFolder, globPattern: string, excludePattern?: string): Promise<vscode.Uri[]> {
-    return await vscode.workspace.findFiles(new vscode.RelativePattern(folder, globPattern), excludePattern ? new vscode.RelativePattern(folder, excludePattern) : undefined, FILE_SEARCH_MAX_RESULT, undefined);
+async function getFileUris(folder: vscode.WorkspaceFolder, globPattern: string, excludePattern?: string, maxResults: number = FILE_SEARCH_MAX_RESULT): Promise<vscode.Uri[]> {
+    return await vscode.workspace.findFiles(new vscode.RelativePattern(folder, globPattern), excludePattern ? new vscode.RelativePattern(folder, excludePattern) : undefined, maxResults, undefined);
 }
 
 export function createFileItem(rootFolder: vscode.WorkspaceFolder, uri: vscode.Uri): Item {
@@ -58,11 +58,11 @@ function getGlobPatterns(globPatterns: string[], languageId: string): string[] {
     return result;
 }
 
-export async function resolveFilesOfPattern(rootFolder: vscode.WorkspaceFolder, filePatterns: string[], excludePattern?: string)
+export async function resolveFilesOfPattern(rootFolder: vscode.WorkspaceFolder, filePatterns: string[], excludePattern?: string, maxResults?: number)
     : Promise<Item[] | undefined> {
     let uris: vscode.Uri[] = [];
     await Promise.all(filePatterns.map(async (pattern: string) => {
-        uris.push(...await getFileUris(rootFolder, pattern, excludePattern));
+        uris.push(...await getFileUris(rootFolder, pattern, excludePattern, maxResults));
     }));
     // de-dupe
     uris = uris.filter((uri, index) => uris.findIndex(uri2 => uri.toString() === uri2.toString()) === index);
@@ -173,11 +173,19 @@ export async function quickPickProjectFileItem(context: IActionContext, fileUri:
     let items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
 
     // If there are no project files and file-based apps are allowed, fall back to offering the .cs files in the workspace
+    let usingFileBasedApps = false;
     if (!items && includeFileBasedApps) {
         items = await resolveFilesOfPattern(rootFolder, [CS_GLOB_PATTERN]);
+        usingFileBasedApps = !!items;
     }
 
-    const fileItem: Item = await quickPickFileItem(context, items, vscode.l10n.t('Choose a project file.'));
+    // Use a distinct placeholder when offering file-based apps (.cs files), since "project file" is misleading for them.
+    // These are intentionally two separate l10n.t calls so each generates its own string ID.
+    const placeHolder = usingFileBasedApps
+        ? vscode.l10n.t('Choose a file-based app.')
+        : vscode.l10n.t('Choose a project file.');
+
+    const fileItem: Item = await quickPickFileItem(context, items, placeHolder);
 
     if (!fileItem) {
         throw new Error(noProjectFileMessage);

--- a/extensions/vscode-containers/src/utils/quickPickFile.ts
+++ b/extensions/vscode-containers/src/utils/quickPickFile.ts
@@ -6,7 +6,7 @@
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from "path";
 import * as vscode from 'vscode';
-import { COMPOSE_FILE_GLOB_PATTERN, CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
+import { COMPOSE_FILE_GLOB_PATTERN, CS_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, NET_BUILD_OUTPUT_EXCLUDE_PATTERN, YAML_GLOB_PATTERN } from "../constants";
 
 export interface Item extends vscode.QuickPickItem {
     relativeFilePath: string;
@@ -173,9 +173,10 @@ export async function quickPickProjectFileItem(context: IActionContext, fileUri:
     let items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
 
     // If there are no project files and file-based apps are allowed, fall back to offering the .cs files in the workspace
+    // (excluding bin/obj so generated .cs files don't show up in the pick).
     let usingFileBasedApps = false;
     if (!items && includeFileBasedApps) {
-        items = await resolveFilesOfPattern(rootFolder, [CS_GLOB_PATTERN]);
+        items = await resolveFilesOfPattern(rootFolder, [CS_GLOB_PATTERN], NET_BUILD_OUTPUT_EXCLUDE_PATTERN);
         usingFileBasedApps = !!items;
     }
 


### PR DESCRIPTION
## TODO

- [x] From Windows host
    - [x] .NET SDK debugging (single file)
    - [x] Regression: .NET SDK debugging (traditional project)
    - [x] Regression: Dockerfile debugging (traditional project)
- [x] From Unix host
    - [x] .NET SDK debugging (single file)
    - [x] Regression: .NET SDK debugging (traditional project)
    - [x] Regression: Dockerfile debugging (traditional project)

Fixes #272

## What

Adds support for debugging **single-file .NET apps** (".NET 10 file-based apps" run via `dotnet run app.cs`) by treating the single `.cs` file as the project and reusing the existing **netSdk** debug flow (which builds & runs an SDK container image via `dotnet publish /t:PublishContainer`, no Dockerfile required).

## Why

File-based apps have no `.csproj`/`.fsproj`, so today F5 doesn't recognize them as .NET projects and there's no way to pick the `.cs` file as the app project. This lets users F5-debug a projectless `.cs` app in a container.

## Changes

- **Detection & selection** — The F5 entry point (`DockerDebugConfigurationProvider.handleEmptyDebugConfig`) now detects a file-based app (a `.cs` file with no project file) and routes it to the netSdk helper. The project quick pick (`quickPickProjectFileItem` / `inferAppProject`) falls back to offering `.cs` files when no `.csproj`/`.fsproj` exists.
- **`PublishAot=false`** — File-based apps enable `PublishAot` by default, which produces a native executable instead of a debuggable managed `.dll`. It's disabled in both the build command and the property-probe so the computed container config matches the image we build.
- **Implicit restore** — `--no-restore` is omitted for file-based apps (there's no prior restore) so `dotnet build app.cs -getProperty:...` works.
- **Web app detection** — `isWebApp` recognizes the `#:sdk Microsoft.NET.Sdk.Web` directive for `.cs` apps.
- **Skip the build-type prompt** — For file-based apps the "Use .NET SDK" vs "Use a Dockerfile" prompt is auto-resolved to SDK, since a Dockerfile flow is meaningless for a projectless `.cs` file.
- **Agent instructions** — Adds `.github/copilot-instructions.md` noting curated files (both `CHANGELOG.md`s, `NOTICE.html`) that must not be auto-edited, and pointing at the repo's PR-review skills.

## Notes for reviewers

- No `CHANGELOG.md` entry is included — the changelog is curated by maintainers as part of the release process (now documented in the new agent instructions).
- `isFileBasedApp(path)` is a pure extension check on a resolved app path; the new folder-level detection decides the prompt-skip before a project is selected. There's some intentional overlap with the F5 folder scan — happy to extract a shared helper if preferred.

Validated with `tsc --noEmit` and `eslint --max-warnings 0`.