### PR TITLE
vscode-container-client: parse compacted Docker port ranges

### DIFF
--- a/NOTICE.html
+++ b/NOTICE.html
@@ -57,219 +57,6 @@ PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            detect-libc 2.1.2 - Apache-2.0
-        </summary>
-        <p><a href="https://github.com/lovell/detect-libc#readme">https://github.com/lovell/detect-libc#readme</a></p>
-        <ul><li>Copyright 2017 Lovell Fuller and others.</li></ul>
-        <pre>
-                                         Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
-      replaced with your own identifying information. (Don&#39;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             ecdsa-sig-formatter 1.0.11 - Apache-2.0
         </summary>
         <p><a href="https://github.com/Brightspace/node-ecdsa-sig-formatter#readme">https://github.com/Brightspace/node-ecdsa-sig-formatter#readme</a></p>
@@ -696,72 +483,6 @@ PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            tunnel-agent 0.6.0 - Apache-2.0
-        </summary>
-        <p><a href="https://github.com/mikeal/tunnel-agent#readme">https://github.com/mikeal/tunnel-agent#readme</a></p>
-        
-        <pre>
-        Apache License
-
-Version 2.0, January 2004
-
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-&quot;License&quot; shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-&quot;Licensor&quot; shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-&quot;Legal Entity&quot; shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, &quot;control&quot; means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-&quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-&quot;Source&quot; form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-&quot;Object&quot; form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-&quot;Work&quot; shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-&quot;Derivative Works&quot; shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-&quot;Contribution&quot; shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, &quot;submitted&quot; means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-&quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of this License; and
-
-You must cause any modified files to carry prominent notices stating that You changed the files; and
-
-You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-
-If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             @pkgjs/parseargs 0.11.0 - Apache-2.0 AND MIT
         </summary>
         <p><a href="https://github.com/pkgjs/parseargs#readme">https://github.com/pkgjs/parseargs#readme</a></p>
@@ -975,43 +696,6 @@ END OF TERMS AND CONDITIONS
 <li>
     <details>
         <summary>
-            rc 1.2.8 - Apache-2.0 OR BSD-2-Clause OR MIT OR (Apache-2.0 AND BSD-2-Clause) OR (Apache-2.0 AND MIT) OR (BSD-2-Clause AND MIT)
-        </summary>
-        <p><a href="https://github.com/dominictarr/rc#readme">https://github.com/dominictarr/rc#readme</a></p>
-        <ul><li>Copyright (c) 2011 Dominic Tarr</li>
-<li>Copyright (c) 2013, Dominic Tarr</li></ul>
-        <pre>
-        The MIT License
-
-Copyright (c) 2011 Dominic Tarr
-
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the &quot;Software&quot;), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
-subject to the following conditions:
-
-The above copyright notice and this permission notice 
-shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             chownr 3.0.0 - BlueOak-1.0.0
         </summary>
         <p><a href="https://github.com/isaacs/chownr#readme">https://github.com/isaacs/chownr#readme</a></p>
@@ -1154,143 +838,9 @@ software or this license, under any kind of legal claim.***
 <li>
     <details>
         <summary>
-            minimatch 10.2.5 - BlueOak-1.0.0
-        </summary>
-        <p><a href="https://github.com/isaacs/minimatch#readme">https://github.com/isaacs/minimatch#readme</a></p>
-        
-        <pre>
-        # Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules. The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor&#39;s
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-&lt;https://blueoakcouncil.org/license/1.0.0&gt;.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice. If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-**_As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim._**
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             minipass 7.1.3 - BlueOak-1.0.0
         </summary>
         <p><a href="https://github.com/isaacs/minipass#readme">https://github.com/isaacs/minipass#readme</a></p>
-        
-        <pre>
-        # Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor&#39;s
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-&lt;https://blueoakcouncil.org/license/1.0.0&gt;.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            tar 7.5.19 - BlueOak-1.0.0
-        </summary>
-        <p><a href="https://github.com/isaacs/node-tar#readme">https://github.com/isaacs/node-tar#readme</a></p>
         
         <pre>
         # Blue Oak Model License
@@ -1580,30 +1130,6 @@ Redistribution and use in source and binary forms, with or without modification,
 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
 * Neither the name of salesforce.com, nor GoInstant, nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            ieee754 1.2.1 - BSD-3-Clause
-        </summary>
-        <p><a href="https://github.com/feross/ieee754#readme">https://github.com/feross/ieee754#readme</a></p>
-        <ul><li>Copyright 2008 Fair Oaks Labs, Inc.</li>
-<li>Copyright (c) 2008, Fair Oaks Labs, Inc.</li></ul>
-        <pre>
-        Copyright 2008 Fair Oaks Labs, Inc.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -1928,68 +1454,14 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            chownr 1.1.4 - ISC
+            graceful-fs 4.2.11 - ISC
         </summary>
-        <p><a href="https://github.com/isaacs/chownr#readme">https://github.com/isaacs/chownr#readme</a></p>
-        <ul><li>Copyright (c) Isaac Z. Schlueter and Contributors</li></ul>
+        <p><a href="https://github.com/isaacs/node-graceful-fs#readme">https://github.com/isaacs/node-graceful-fs#readme</a></p>
+        <ul><li>Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors</li></ul>
         <pre>
         The ISC License
 
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            ini 1.3.8 - ISC
-        </summary>
-        <p><a href="https://github.com/isaacs/ini#readme">https://github.com/isaacs/ini#readme</a></p>
-        <ul><li>Copyright (c) Isaac Z. Schlueter and Contributors</li></ul>
-        <pre>
-        The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            once 1.4.0 - ISC
-        </summary>
-        <p><a href="https://github.com/isaacs/once#readme">https://github.com/isaacs/once#readme</a></p>
-        <ul><li>Copyright (c) Isaac Z. Schlueter and Contributors</li></ul>
-        <pre>
-        The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
+Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -2064,33 +1536,6 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            wrappy 1.0.2 - ISC
-        </summary>
-        <p><a href="https://github.com/npm/wrappy">https://github.com/npm/wrappy</a></p>
-        <ul><li>Copyright (c) Isaac Z. Schlueter and Contributors</li></ul>
-        <pre>
-        The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             yaml 2.9.0 - ISC
         </summary>
         <p><a href="https://eemeli.org/yaml/">https://eemeli.org/yaml/</a></p>
@@ -2109,528 +1554,6 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
 OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-alpine-arm64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler Qkkbal</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-alpine-x64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>(c) E Pffff</li>
-<li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler Qkkbal</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-darwin-arm64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-darwin-x64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-linux-arm 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler Qkkbal</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-linux-arm64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler Qkkbal</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-linux-x64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>(c) E Pffff</li>
-<li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler Qkkbal</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-win32-arm64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @vscode/vsce-sign-win32-x64 2.0.6 - LicenseRef-scancode-ms-xamarin-uitest3.2.0
-        </summary>
-        <p><a href="https://github.com/Microsoft/node-vscode-sign">https://github.com/Microsoft/node-vscode-sign</a></p>
-        <ul><li>Copyright 1995-2024 Mark Adler</li>
-<li>Copyright 1995-2024 Jean-loup Gailly and Mark Adler</li></ul>
-        <pre>
-        MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT VSCE-SIGN
-  
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
-
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
-
-1. INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, Azure DevOps, Team Foundation Server, Code Spaces and successor Microsoft products and services (collectively, the &quot;Visual Studio Products and Services&quot;) to develop and test your applications.
-
-2. TERMS FOR SPECIFIC COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the notices file(s) accompanying the software.
-
-3. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
-* work around any technical limitations in the software;
-* reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software except, and only to the extent required by third party licensing terms governing the use of certain open source components that may be included in the software;
-* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
-* use the software in any way that is against the law; 
-* share, publish, rent or lease the software; or 
-* provide the software as a stand-alone offering or combined with any of your applications for others to use, or transfer the software or this agreement to any third party.
-
-4. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting. 
-
-5. SUPPORT SERVICES. Because this software is &quot;as is,&quot; we may not provide support services for it.
-
-6. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-7. APPLICABLE LAW. If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
-
-8. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-
-b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-
-c. Germany and Austria.
-(i)	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-(ii)	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-
-9. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &quot;AS-IS.&quot; YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-10. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/abort-controller 2.1.2 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller/README.md</a></p>
-        <ul><li>Copyright (c) 2020 Microsoft</li>
-<li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2020 Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
         </pre>
     </details>
@@ -2883,39 +1806,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/arm-resources-subscriptions 2.1.0 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resources-subscriptions/arm-resources-subscriptions">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/resources-subscriptions/arm-resources-subscriptions</a></p>
-        <ul><li>Copyright (c) 2023 Microsoft</li>
-<li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2023 Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             @azure/arm-storage 18.6.0 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/arm-storage">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/storage/arm-storage</a></p>
@@ -3004,72 +1894,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/core-auth 1.10.1 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-auth/README.md">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-auth/README.md</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/core-client 1.10.2 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client/">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client/</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             @azure/core-lro 2.7.2 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-lro/README.md">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-lro/README.md</a></p>
@@ -3104,175 +1928,9 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/core-paging 1.6.2 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-paging/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-paging/README.md</a></p>
-        <ul><li>Copyright (c) 2020 Microsoft</li>
-<li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2020 Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/core-rest-pipeline 1.24.0 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-rest-pipeline/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-rest-pipeline/README.md</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/core-tracing 1.3.1 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-tracing/README.md">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-tracing/README.md</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/core-util 1.13.1 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-util/">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-util/</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             @azure/identity 4.13.1 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure/logger 1.3.0 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger/README.md</a></p>
         <ul><li>Copyright (c) Microsoft Corporation</li></ul>
         <pre>
         Copyright (c) Microsoft Corporation.
@@ -3329,39 +1987,6 @@ SOFTWARE.
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            @azure-rest/core-client 2.7.0 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/">https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
         </pre>
     </details>
@@ -3494,39 +2119,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @typespec/ts-http-runtime 0.3.6 - MIT
-        </summary>
-        <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/ts-http-runtime/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/ts-http-runtime/README.md</a></p>
-        <ul><li>Copyright (c) Microsoft Corporation</li></ul>
-        <pre>
-        Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             agent-base 7.1.4 - MIT
         </summary>
         <p><a href="https://github.com/TooTallNate/proxy-agents#readme">https://github.com/TooTallNate/proxy-agents#readme</a></p>
@@ -3589,134 +2181,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            base64-js 1.5.1 - MIT
-        </summary>
-        <p><a href="https://github.com/beatgammit/base64-js">https://github.com/beatgammit/base64-js</a></p>
-        <ul><li>Copyright (c) 2014 Jameson Little</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2014 Jameson Little
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            bl 4.1.0 - MIT
-        </summary>
-        <p><a href="https://github.com/rvagg/bl">https://github.com/rvagg/bl</a></p>
-        <ul><li>Copyright (c) 2013-2019 bl contributors</li></ul>
-        <pre>
-        The MIT License (MIT)
-=====================
-
-Copyright (c) 2013-2019 bl contributors
-----------------------------------
-
-*bl contributors listed at &lt;https://github.com/rvagg/bl#contributors&gt;*
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            brace-expansion 5.0.7 - MIT
-        </summary>
-        <p><a href="https://github.com/juliangruber/brace-expansion#readme">https://github.com/juliangruber/brace-expansion#readme</a></p>
-        <ul><li>Copyright Isaac Z. Schlueter &lt;i@izs.me&gt;</li>
-<li>Copyright Julian Gruber &lt;julian@juliangruber.com&gt;</li></ul>
-        <pre>
-        MIT License
-
-Copyright Julian Gruber &lt;julian@juliangruber.com&gt;
-
-TypeScript port Copyright Isaac Z. Schlueter &lt;i@izs.me&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            buffer 5.7.1 - MIT
-        </summary>
-        <p><a href="https://github.com/feross/buffer">https://github.com/feross/buffer</a></p>
-        <ul><li>Copyright (c) Feross Aboukhadijeh, and other contributors</li>
-<li>Copyright (c) Feross Aboukhadijeh (http://feross.org), and other contributors</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Feross Aboukhadijeh, and other contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
         </pre>
     </details>
@@ -3804,60 +2268,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMA
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            decompress-response 6.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/sindresorhus/decompress-response#readme">https://github.com/sindresorhus/decompress-response#readme</a></p>
-        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            deep-extend 0.6.0 - MIT
-        </summary>
-        <p><a href="https://github.com/unclechu/node-deep-extend">https://github.com/unclechu/node-deep-extend</a></p>
-        <ul><li>Copyright (c) 2013-2018 Viacheslav Lotsmanov</li>
-<li>Copyright (c) 2013-2018, Viacheslav Lotsmanov</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2013-2018, Viacheslav Lotsmanov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         </pre>
     </details>
@@ -4053,38 +2463,6 @@ THE SOFTWARE IS PROVIDED &#39;AS IS&#39;, WITHOUT WARRANTY OF ANY KIND, EXPRESS 
 <li>
     <details>
         <summary>
-            end-of-stream 1.4.5 - MIT
-        </summary>
-        <p><a href="https://github.com/mafintosh/end-of-stream">https://github.com/mafintosh/end-of-stream</a></p>
-        <ul><li>Copyright (c) 2014 Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2014 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             events 3.3.0 - MIT
         </summary>
         <p><a href="https://github.com/Gozala/events#readme">https://github.com/Gozala/events#readme</a></p>
@@ -4112,39 +2490,6 @@ NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            fs-constants 1.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/mafintosh/fs-constants">https://github.com/mafintosh/fs-constants</a></p>
-        <ul><li>Copyright (c) 2018 Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2018 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
         </pre>
     </details>
@@ -4180,36 +2525,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            github-from-package 0.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/substack/github-from-package">https://github.com/substack/github-from-package</a></p>
-        
-        <pre>
-        This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         </pre>
     </details>
@@ -4445,6 +2760,34 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 <li>
     <details>
         <summary>
+            jsonfile 6.2.1 - MIT
+        </summary>
+        <p><a href="https://github.com/jprichardson/node-jsonfile#readme">https://github.com/jprichardson/node-jsonfile#readme</a></p>
+        <ul><li>Copyright 2012-2016, JP Richardson &lt;jprichardson@gmail.com&gt;</li>
+<li>Copyright (c) 2012-2015, JP Richardson &lt;jprichardson@gmail.com&gt;</li></ul>
+        <pre>
+        (The MIT License)
+
+Copyright (c) 2012-2015, JP Richardson &lt;jprichardson@gmail.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the &#39;Software&#39;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+ merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &#39;AS IS&#39;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             jsonwebtoken 9.0.3 - MIT
         </summary>
         <p><a href="https://github.com/auth0/node-jsonwebtoken#readme">https://github.com/auth0/node-jsonwebtoken#readme</a></p>
@@ -4530,38 +2873,6 @@ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PA
 PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
 FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            keytar 7.9.0 - MIT
-        </summary>
-        <p><a href="http://atom.github.io/node-keytar">http://atom.github.io/node-keytar</a></p>
-        <ul><li>Copyright (c) 2013 GitHub Inc.</li></ul>
-        <pre>
-        Copyright (c) 2013 GitHub Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-&quot;Software&quot;), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         </pre>
     </details>
@@ -4771,27 +3082,6 @@ terms above.
 <li>
     <details>
         <summary>
-            mimic-response 3.1.0 - MIT
-        </summary>
-        <p><a href="https://github.com/sindresorhus/mimic-response#readme">https://github.com/sindresorhus/mimic-response#readme</a></p>
-        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             minimist 1.2.8 - MIT
         </summary>
         <p><a href="https://github.com/minimistjs/minimist">https://github.com/minimistjs/minimist</a></p>
@@ -4862,39 +3152,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            mkdirp-classic 0.5.3 - MIT
-        </summary>
-        <p><a href="https://github.com/mafintosh/mkdirp-classic">https://github.com/mafintosh/mkdirp-classic</a></p>
-        <ul><li>Copyright (c) 2020 James Halliday (mail@substack.net) and Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2020 James Halliday (mail@substack.net) and Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             ms 2.1.3 - MIT
         </summary>
         <p><a href="https://github.com/vercel/ms#readme">https://github.com/vercel/ms#readme</a></p>
@@ -4903,39 +3160,6 @@ THE SOFTWARE.
         The MIT License (MIT)
 
 Copyright (c) 2020 Vercel, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            napi-build-utils 2.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/inspiredware/napi-build-utils#readme">https://github.com/inspiredware/napi-build-utils#readme</a></p>
-        <ul><li>Copyright (c) 2018 inspiredware</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) 2018 inspiredware
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -4990,30 +3214,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            node-addon-api 4.3.0 - MIT
-        </summary>
-        <p><a href="https://github.com/nodejs/node-addon-api">https://github.com/nodejs/node-addon-api</a></p>
-        <ul><li>Copyright (c) 2017 Node.js</li></ul>
-        <pre>
-        The MIT License (MIT)
-=====================
-
-Copyright (c) 2017 Node.js API collaborators
------------------------------------
-
-*Node.js API collaborators listed at &lt;https://github.com/nodejs/node-addon-api#collaborators&gt;*
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         </pre>
     </details>
 </li>
@@ -5111,131 +3311,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            prebuild-install 7.1.3 - MIT
-        </summary>
-        <p><a href="https://github.com/prebuild/prebuild-install">https://github.com/prebuild/prebuild-install</a></p>
-        <ul><li>Copyright (c) 2015 Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2015 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            pump 3.0.4 - MIT
-        </summary>
-        <p><a href="https://github.com/mafintosh/pump#readme">https://github.com/mafintosh/pump#readme</a></p>
-        <ul><li>Copyright (c) 2014 Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2014 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            readable-stream 3.6.2 - MIT
-        </summary>
-        <p><a href="https://github.com/nodejs/readable-stream#readme">https://github.com/nodejs/readable-stream#readme</a></p>
-        <ul><li>Copyright Node.js contributors</li>
-<li>Copyright Joyent, Inc. and other Node contributors</li></ul>
-        <pre>
-        Node.js is licensed for use as follows:
-
-&quot;&quot;&quot;
-Copyright Node.js contributors. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-&quot;&quot;&quot;
-
-This license applies to parts of Node.js originating from the
-https://github.com/joyent/node repository:
-
-&quot;&quot;&quot;
-Copyright Joyent, Inc. and other Node contributors. All rights reserved.
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-&quot;&quot;&quot;
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             run-applescript 7.1.0 - MIT
         </summary>
         <p><a href="https://github.com/sindresorhus/run-applescript#readme">https://github.com/sindresorhus/run-applescript#readme</a></p>
@@ -5324,199 +3399,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            simple-concat 1.0.1 - MIT
-        </summary>
-        <p><a href="https://github.com/feross/simple-concat">https://github.com/feross/simple-concat</a></p>
-        <ul><li>Copyright (c) Feross Aboukhadijeh</li>
-<li>Copyright (c) Feross Aboukhadijeh (http://feross.org)</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Feross Aboukhadijeh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            simple-get 4.0.1 - MIT
-        </summary>
-        <p><a href="https://github.com/feross/simple-get">https://github.com/feross/simple-get</a></p>
-        <ul><li>Copyright (c) Feross Aboukhadijeh</li>
-<li>Copyright (c) Feross Aboukhadijeh (http://feross.org)</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Feross Aboukhadijeh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            string_decoder 1.3.0 - MIT
-        </summary>
-        <p><a href="https://github.com/nodejs/string_decoder">https://github.com/nodejs/string_decoder</a></p>
-        <ul><li>Copyright Node.js contributors</li>
-<li>Copyright Joyent, Inc. and other Node contributors</li></ul>
-        <pre>
-        Node.js is licensed for use as follows:
-
-&quot;&quot;&quot;
-Copyright Node.js contributors. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-&quot;&quot;&quot;
-
-This license applies to parts of Node.js originating from the
-https://github.com/joyent/node repository:
-
-&quot;&quot;&quot;
-Copyright Joyent, Inc. and other Node contributors. All rights reserved.
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-&quot;&quot;&quot;
-
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            strip-json-comments 2.0.1 - MIT
-        </summary>
-        <p><a href="https://github.com/sindresorhus/strip-json-comments#readme">https://github.com/sindresorhus/strip-json-comments#readme</a></p>
-        <ul><li>(c) Sindre Sorhus (http://sindresorhus.com)</li>
-<li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            tar-stream 2.2.0 - MIT
-        </summary>
-        <p><a href="https://github.com/mafintosh/tar-stream">https://github.com/mafintosh/tar-stream</a></p>
-        <ul><li>Copyright (c) 2014 Mathias Buus</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2014 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             tree-kill 1.2.2 - MIT
         </summary>
         <p><a href="https://github.com/pkrumins/node-tree-kill">https://github.com/pkrumins/node-tree-kill</a></p>
@@ -5543,6 +3425,38 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            universalify 2.0.1 - MIT
+        </summary>
+        <p><a href="https://github.com/RyanZim/universalify#readme">https://github.com/RyanZim/universalify#readme</a></p>
+        <ul><li>Copyright (c) 2017, Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;</li></ul>
+        <pre>
+        (The MIT License)
+
+Copyright (c) 2017, Ryan Zimmerman &lt;opensrc@ryanzim.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the &#39;Software&#39;), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &#39;AS IS&#39;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         </pre>
     </details>
@@ -5764,26 +3678,6 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 <li>
     <details>
         <summary>
-            xml-naming 0.1.0 - MIT
-        </summary>
-        <p><a href="https://github.com/NaturalIntelligence/xml-naming#readme">https://github.com/NaturalIntelligence/xml-naming#readme</a></p>
-        
-        <pre>
-        MIT License
-
-Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             zod 4.4.3 - MIT
         </summary>
         <p><a href="https://zod.dev/">https://zod.dev/</a></p>
@@ -5811,38 +3705,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            expand-template 2.0.3 - MIT OR (MIT AND WTFPL)
-        </summary>
-        <p><a href="https://github.com/ralphtheninja/expand-template">https://github.com/ralphtheninja/expand-template</a></p>
-        <ul><li>Copyright (c) 2018 Lars-Magnus Skog</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) 2018 Lars-Magnus Skog
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
         </pre>
     </details>
 </li>

--- a/extensions/vscode-containers/package.json
+++ b/extensions/vscode-containers/package.json
@@ -1227,7 +1227,8 @@
                                             "description": "%vscode-containers.tasks.docker-run.dockerRun.ports.protocol%",
                                             "enum": [
                                                 "tcp",
-                                                "udp"
+                                                "udp",
+                                                "sctp"
                                             ]
                                         }
                                     },

--- a/extensions/vscode-containers/package.nls.json
+++ b/extensions/vscode-containers/package.nls.json
@@ -81,7 +81,7 @@
     "vscode-containers.tasks.docker-run.dockerRun.ports.description": "Ports that are going to be mapped on the host.",
     "vscode-containers.tasks.docker-run.dockerRun.ports.hostPort": "Port number to be bound on the host.",
     "vscode-containers.tasks.docker-run.dockerRun.ports.containerPort": "Port number of the container to be bound.",
-    "vscode-containers.tasks.docker-run.dockerRun.ports.protocol": "Specific protocol for the binding (`tcp | udp`).",
+    "vscode-containers.tasks.docker-run.dockerRun.ports.protocol": "Specific protocol for the binding (`tcp | udp | sctp`).",
     "vscode-containers.tasks.docker-run.dockerRun.portsPublishAll": "Whether to publish all exposed container ports to random ports on the host.",
     "vscode-containers.tasks.docker-run.dockerRun.remove": "Whether to clean up the container and remove the file system when the container exits.",
     "vscode-containers.tasks.docker-run.dockerRun.extraHosts.description": "Hosts to be added to the container's `hosts` file for DNS resolution.",

--- a/extensions/vscode-containers/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/extensions/vscode-containers/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -14,7 +14,7 @@ export interface DockerContainerExtraHost {
 export interface DockerContainerPort {
     hostPort?: number;
     containerPort: number;
-    protocol?: 'tcp' | 'udp';
+    protocol?: 'tcp' | 'udp' | 'sctp';
 }
 
 export interface DockerContainerVolume {

--- a/packages/vscode-container-client/CHANGELOG.md
+++ b/packages/vscode-container-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 - 3 August 2026
+## 1.1.0 - 6 August 2026
 ### Added
 * Added client for Nerdctl. [#119](https://github.com/microsoft/vscode-containers/issues/119)
 * Added client for WSL-native containers (`wslc`). [#501](https://github.com/microsoft/vscode-containers/issues/501)

--- a/packages/vscode-container-client/src/clients/DockerClientBase/SharedListContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/SharedListContainerRecord.ts
@@ -6,7 +6,7 @@
 import * as z from 'zod/mini';
 import type { ListContainersItem, PortBinding } from '../../contracts/ContainerClient';
 import { imageNameSchema, labelsStringSchema } from '../../contracts/ZodTransforms';
-import { parseDockerRawPortString } from './parseDockerRawPortString';
+import { parseDockerRawPortStringList } from './parseDockerRawPortString';
 import { resolveCreatedAt, type CreatedAtMode } from './resolveCreatedAt';
 
 /**
@@ -186,9 +186,9 @@ function resolvePorts(portsStr: string | undefined, strict: boolean, throwOnUnpa
             continue;
         }
 
-        const parsed = parseDockerRawPortString(trimmed);
+        const parsed = parseDockerRawPortStringList(trimmed);
         if (parsed) {
-            ports.push(parsed);
+            ports.push(...parsed);
         } else if (strict && throwOnUnparseablePort) {
             throw new Error('Invalid container JSON');
         }

--- a/packages/vscode-container-client/src/clients/DockerClientBase/SharedListContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/SharedListContainerRecord.ts
@@ -6,7 +6,7 @@
 import * as z from 'zod/mini';
 import type { ListContainersItem, PortBinding } from '../../contracts/ContainerClient';
 import { imageNameSchema, labelsStringSchema } from '../../contracts/ZodTransforms';
-import { parseDockerRawPortStringList } from './parseDockerRawPortString';
+import { expandDockerRawPortString } from './parseDockerRawPortString';
 import { resolveCreatedAt, type CreatedAtMode } from './resolveCreatedAt';
 
 /**
@@ -186,7 +186,7 @@ function resolvePorts(portsStr: string | undefined, strict: boolean, throwOnUnpa
             continue;
         }
 
-        const parsed = parseDockerRawPortStringList(trimmed);
+        const parsed = expandDockerRawPortString(trimmed);
         if (parsed) {
             ports.push(...parsed);
         } else if (strict && throwOnUnparseablePort) {

--- a/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
@@ -36,6 +36,7 @@ export function parseExposedPortKey(key: string): { containerPort: number; proto
 }
 
 const shortFormRegex = /^(?<containerPort>\d+)\/(?<protocol>tcp|udp)$/i;
+const shortRangeFormRegex = /^(?<containerPortStart>\d+)-(?<containerPortEnd>\d+)\/(?<protocol>tcp|udp)$/i;
 
 // Supports:
 // - hostPort->containerPort[/protocol]
@@ -46,6 +47,7 @@ const shortFormRegex = /^(?<containerPort>\d+)\/(?<protocol>tcp|udp)$/i;
 //   `:` before the host port, so embedded IPv6 colons are preserved; brackets
 //   (if any) are stripped by normalizeIpAddress.
 const longFormRegex = /^(?:(?<host>\[[^\]]*\]|[^\s]*?):)?(?<hostPort>\d+)\s*->\s*(?<containerPort>\d+)(?:\/(?<protocol>tcp|udp))?$/i;
+const longRangeFormRegex = /^(?:(?<host>\[[^\]]*\]|[^\s]*?):)?(?<hostPortStart>\d+)-(?<hostPortEnd>\d+)\s*->\s*(?<containerPortStart>\d+)-(?<containerPortEnd>\d+)(?:\/(?<protocol>tcp|udp))?$/i;
 
 /**
  * Attempt to parse a Docker-like raw port binding string
@@ -80,4 +82,59 @@ export function parseDockerRawPortString(portString: string): PortBinding | unde
         containerPort: Number.parseInt(longMatch.groups.containerPort, 10),
         protocol,
     };
+}
+
+/**
+ * Parse a Docker-style port string into one or more bindings. Docker compacts
+ * consecutive ports into ranges in `ps` output, such as `10000-10002/tcp` or
+ * `0.0.0.0:10000-10002->10000-10002/tcp`.
+ */
+export function parseDockerRawPortStringList(portString: string): PortBinding[] | undefined {
+    const singlePort = parseDockerRawPortString(portString);
+    if (singlePort) {
+        return [singlePort];
+    }
+
+    const trimmed = portString.trim();
+    const shortRangeMatch = shortRangeFormRegex.exec(trimmed);
+    if (shortRangeMatch?.groups) {
+        const containerPortStart = Number.parseInt(shortRangeMatch.groups.containerPortStart, 10);
+        const containerPortEnd = Number.parseInt(shortRangeMatch.groups.containerPortEnd, 10);
+        if (containerPortEnd < containerPortStart) {
+            return undefined;
+        }
+
+        const protocol = shortRangeMatch.groups.protocol.toLowerCase() as 'tcp' | 'udp';
+        return Array.from(
+            { length: containerPortEnd - containerPortStart + 1 },
+            (_, offset) => ({ containerPort: containerPortStart + offset, protocol }),
+        );
+    }
+
+    const longRangeMatch = longRangeFormRegex.exec(trimmed);
+    if (!longRangeMatch?.groups) {
+        return undefined;
+    }
+
+    const hostPortStart = Number.parseInt(longRangeMatch.groups.hostPortStart, 10);
+    const hostPortEnd = Number.parseInt(longRangeMatch.groups.hostPortEnd, 10);
+    const containerPortStart = Number.parseInt(longRangeMatch.groups.containerPortStart, 10);
+    const containerPortEnd = Number.parseInt(longRangeMatch.groups.containerPortEnd, 10);
+    const hostRangeLength = hostPortEnd - hostPortStart;
+    const containerRangeLength = containerPortEnd - containerPortStart;
+    if (hostRangeLength < 0 || hostRangeLength !== containerRangeLength) {
+        return undefined;
+    }
+
+    const hostIp = normalizeIpAddress(longRangeMatch.groups.host);
+    const protocol = normalizeProtocol(longRangeMatch.groups.protocol) ?? 'tcp';
+    return Array.from(
+        { length: containerRangeLength + 1 },
+        (_, offset) => ({
+            ...(hostIp !== undefined ? { hostIp } : {}),
+            hostPort: hostPortStart + offset,
+            containerPort: containerPortStart + offset,
+            protocol,
+        }),
+    );
 }

--- a/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
@@ -37,6 +37,7 @@ export function parseExposedPortKey(key: string): { containerPort: number; proto
 
 const shortFormRegex = /^(?<containerPort>\d+)\/(?<protocol>tcp|udp)$/i;
 const shortRangeFormRegex = /^(?<containerPortStart>\d+)-(?<containerPortEnd>\d+)\/(?<protocol>tcp|udp)$/i;
+const maxPort = 65535;
 
 // Supports:
 // - hostPort->containerPort[/protocol]
@@ -100,7 +101,7 @@ export function parseDockerRawPortStringList(portString: string): PortBinding[] 
     if (shortRangeMatch?.groups) {
         const containerPortStart = Number.parseInt(shortRangeMatch.groups.containerPortStart, 10);
         const containerPortEnd = Number.parseInt(shortRangeMatch.groups.containerPortEnd, 10);
-        if (containerPortEnd < containerPortStart) {
+        if (!isValidPortRange(containerPortStart, containerPortEnd)) {
             return undefined;
         }
 
@@ -122,7 +123,11 @@ export function parseDockerRawPortStringList(portString: string): PortBinding[] 
     const containerPortEnd = Number.parseInt(longRangeMatch.groups.containerPortEnd, 10);
     const hostRangeLength = hostPortEnd - hostPortStart;
     const containerRangeLength = containerPortEnd - containerPortStart;
-    if (hostRangeLength < 0 || hostRangeLength !== containerRangeLength) {
+    if (
+        !isValidPortRange(hostPortStart, hostPortEnd)
+        || !isValidPortRange(containerPortStart, containerPortEnd)
+        || hostRangeLength !== containerRangeLength
+    ) {
         return undefined;
     }
 
@@ -137,4 +142,12 @@ export function parseDockerRawPortStringList(portString: string): PortBinding[] 
             protocol,
         }),
     );
+}
+
+function isValidPortRange(start: number, end: number): boolean {
+    return Number.isSafeInteger(start)
+        && Number.isSafeInteger(end)
+        && start >= 0
+        && end >= start
+        && end <= maxPort;
 }

--- a/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
+++ b/packages/vscode-container-client/src/clients/DockerClientBase/parseDockerRawPortString.ts
@@ -7,15 +7,17 @@ import type { PortBinding } from '../../contracts/ContainerClient';
 import { normalizeIpAddress } from './normalizeIpAddress';
 
 /**
- * Normalize a raw protocol token to the supported set. Returns 'tcp' or 'udp'
+ * Normalize a raw protocol token to the supported set. Returns 'tcp', 'udp', or 'sctp'
  * (case-insensitive) or undefined for anything else (including undefined input).
  */
-export function normalizeProtocol(protocol: string | undefined): 'tcp' | 'udp' | undefined {
+export function normalizeProtocol(protocol: string | undefined): PortBinding['protocol'] {
     switch (protocol?.toLowerCase()) {
         case 'tcp':
             return 'tcp';
         case 'udp':
             return 'udp';
+        case 'sctp':
+            return 'sctp';
         default:
             return undefined;
     }
@@ -26,7 +28,7 @@ export function normalizeProtocol(protocol: string | undefined): 'tcp' | 'udp' |
  * (e.g. "80/tcp"). Returns the numeric container port and normalized protocol, or
  * undefined when the container port is not a finite integer.
  */
-export function parseExposedPortKey(key: string): { containerPort: number; protocol: 'tcp' | 'udp' | undefined } | undefined {
+export function parseExposedPortKey(key: string): Pick<PortBinding, 'containerPort' | 'protocol'> | undefined {
     const [port, protocol] = key.split('/');
     const containerPort = parseInt(port, 10);
     if (!Number.isFinite(containerPort)) {
@@ -35,9 +37,7 @@ export function parseExposedPortKey(key: string): { containerPort: number; proto
     return { containerPort, protocol: normalizeProtocol(protocol) };
 }
 
-const shortFormRegex = /^(?<containerPort>\d+)\/(?<protocol>tcp|udp)$/i;
-const shortRangeFormRegex = /^(?<containerPortStart>\d+)-(?<containerPortEnd>\d+)\/(?<protocol>tcp|udp)$/i;
-const maxPort = 65535;
+const shortFormRegex = /^(?<containerPortStart>\d+)(?:-(?<containerPortEnd>\d+))?\/(?<protocol>tcp|udp|sctp)$/i;
 
 // Supports:
 // - hostPort->containerPort[/protocol]
@@ -47,15 +47,14 @@ const maxPort = 65535;
 //   or `::1:8080->80/tcp`. The optional host is captured lazily up to the last
 //   `:` before the host port, so embedded IPv6 colons are preserved; brackets
 //   (if any) are stripped by normalizeIpAddress.
-const longFormRegex = /^(?:(?<host>\[[^\]]*\]|[^\s]*?):)?(?<hostPort>\d+)\s*->\s*(?<containerPort>\d+)(?:\/(?<protocol>tcp|udp))?$/i;
-const longRangeFormRegex = /^(?:(?<host>\[[^\]]*\]|[^\s]*?):)?(?<hostPortStart>\d+)-(?<hostPortEnd>\d+)\s*->\s*(?<containerPortStart>\d+)-(?<containerPortEnd>\d+)(?:\/(?<protocol>tcp|udp))?$/i;
+const longFormRegex = /^(?:(?<host>\[[^\]]*\]|[^\s]*?):)?(?<hostPortStart>\d+)(?:-(?<hostPortEnd>\d+))?\s*->\s*(?<containerPortStart>\d+)(?:-(?<containerPortEnd>\d+))?(?:\/(?<protocol>tcp|udp|sctp))?$/i;
 
 /**
- * Attempt to parse a Docker-like raw port binding string
+ * Parse and expand a Docker-like raw port binding string.
  * @param portString the raw port string to parse, e.g. "1234/tcp" or "0.0.0.0:1234->1234/udp"
- * @returns Parsed raw port string as a PortBinding record or undefined if invalid
+ * @returns Parsed bindings, or undefined if invalid
  */
-export function parseDockerRawPortString(portString: string): PortBinding | undefined {
+export function expandDockerRawPortString(portString: string): PortBinding[] | undefined {
     const trimmed = portString.trim();
     if (!trimmed) {
         return undefined;
@@ -63,10 +62,19 @@ export function parseDockerRawPortString(portString: string): PortBinding | unde
 
     const shortMatch = shortFormRegex.exec(trimmed);
     if (shortMatch?.groups) {
-        return {
-            containerPort: Number.parseInt(shortMatch.groups.containerPort, 10),
-            protocol: shortMatch.groups.protocol.toLowerCase() as 'tcp' | 'udp',
-        };
+        const containerPortStart = Number.parseInt(shortMatch.groups.containerPortStart, 10);
+        const containerPortEnd = shortMatch.groups.containerPortEnd
+            ? Number.parseInt(shortMatch.groups.containerPortEnd, 10)
+            : containerPortStart;
+        if (!isValidPortRange(containerPortStart, containerPortEnd)) {
+            return undefined;
+        }
+
+        const protocol = normalizeProtocol(shortMatch.groups.protocol);
+        return Array.from(
+            { length: containerPortEnd - containerPortStart + 1 },
+            (_, offset) => ({ containerPort: containerPortStart + offset, protocol }),
+        );
     }
 
     const longMatch = longFormRegex.exec(trimmed);
@@ -74,53 +82,14 @@ export function parseDockerRawPortString(portString: string): PortBinding | unde
         return undefined;
     }
 
-    const hostIp = normalizeIpAddress(longMatch.groups.host);
-    const protocol = normalizeProtocol(longMatch.groups.protocol) ?? 'tcp';
-
-    return {
-        ...(hostIp !== undefined ? { hostIp } : {}),
-        hostPort: Number.parseInt(longMatch.groups.hostPort, 10),
-        containerPort: Number.parseInt(longMatch.groups.containerPort, 10),
-        protocol,
-    };
-}
-
-/**
- * Parse a Docker-style port string into one or more bindings. Docker compacts
- * consecutive ports into ranges in `ps` output, such as `10000-10002/tcp` or
- * `0.0.0.0:10000-10002->10000-10002/tcp`.
- */
-export function parseDockerRawPortStringList(portString: string): PortBinding[] | undefined {
-    const singlePort = parseDockerRawPortString(portString);
-    if (singlePort) {
-        return [singlePort];
-    }
-
-    const trimmed = portString.trim();
-    const shortRangeMatch = shortRangeFormRegex.exec(trimmed);
-    if (shortRangeMatch?.groups) {
-        const containerPortStart = Number.parseInt(shortRangeMatch.groups.containerPortStart, 10);
-        const containerPortEnd = Number.parseInt(shortRangeMatch.groups.containerPortEnd, 10);
-        if (!isValidPortRange(containerPortStart, containerPortEnd)) {
-            return undefined;
-        }
-
-        const protocol = shortRangeMatch.groups.protocol.toLowerCase() as 'tcp' | 'udp';
-        return Array.from(
-            { length: containerPortEnd - containerPortStart + 1 },
-            (_, offset) => ({ containerPort: containerPortStart + offset, protocol }),
-        );
-    }
-
-    const longRangeMatch = longRangeFormRegex.exec(trimmed);
-    if (!longRangeMatch?.groups) {
-        return undefined;
-    }
-
-    const hostPortStart = Number.parseInt(longRangeMatch.groups.hostPortStart, 10);
-    const hostPortEnd = Number.parseInt(longRangeMatch.groups.hostPortEnd, 10);
-    const containerPortStart = Number.parseInt(longRangeMatch.groups.containerPortStart, 10);
-    const containerPortEnd = Number.parseInt(longRangeMatch.groups.containerPortEnd, 10);
+    const hostPortStart = Number.parseInt(longMatch.groups.hostPortStart, 10);
+    const hostPortEnd = longMatch.groups.hostPortEnd
+        ? Number.parseInt(longMatch.groups.hostPortEnd, 10)
+        : hostPortStart;
+    const containerPortStart = Number.parseInt(longMatch.groups.containerPortStart, 10);
+    const containerPortEnd = longMatch.groups.containerPortEnd
+        ? Number.parseInt(longMatch.groups.containerPortEnd, 10)
+        : containerPortStart;
     const hostRangeLength = hostPortEnd - hostPortStart;
     const containerRangeLength = containerPortEnd - containerPortStart;
     if (
@@ -131,8 +100,8 @@ export function parseDockerRawPortStringList(portString: string): PortBinding[] 
         return undefined;
     }
 
-    const hostIp = normalizeIpAddress(longRangeMatch.groups.host);
-    const protocol = normalizeProtocol(longRangeMatch.groups.protocol) ?? 'tcp';
+    const hostIp = normalizeIpAddress(longMatch.groups.host);
+    const protocol = normalizeProtocol(longMatch.groups.protocol) ?? 'tcp';
     return Array.from(
         { length: containerRangeLength + 1 },
         (_, offset) => ({
@@ -143,6 +112,8 @@ export function parseDockerRawPortStringList(portString: string): PortBinding[] 
         }),
     );
 }
+
+const maxPort = 65535;
 
 function isValidPortRange(start: number, end: number): boolean {
     return Number.isSafeInteger(start)

--- a/packages/vscode-container-client/src/clients/PodmanClient/PodmanListContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/PodmanClient/PodmanListContainerRecord.ts
@@ -10,7 +10,7 @@ const PodmanPortBindingSchema = z.object({
     host_ip: z.optional(z.string()),
     container_port: z.number(),
     host_port: z.optional(z.number()),
-    protocol: z.enum(['udp', 'tcp']),
+    protocol: z.enum(['udp', 'tcp', 'sctp']),
     /* eslint-enable @typescript-eslint/naming-convention */
 });
 

--- a/packages/vscode-container-client/src/clients/WslcClient/WslcListContainerRecord.ts
+++ b/packages/vscode-container-client/src/clients/WslcClient/WslcListContainerRecord.ts
@@ -67,12 +67,14 @@ export function mapWslcContainerState(state: number | undefined): string {
  * Map the IANA protocol number wslc reports for a port binding onto the protocol
  * names used by the {@link PortBinding} contract.
  */
-function mapWslcProtocol(protocol: number | undefined): 'tcp' | 'udp' | undefined {
+function mapWslcProtocol(protocol: number | undefined): PortBinding['protocol'] {
     switch (protocol) {
         case 6:
             return 'tcp';
         case 17:
             return 'udp';
+        case 132:
+            return 'sctp';
         default:
             return undefined;
     }

--- a/packages/vscode-container-client/src/contracts/ContainerClient.ts
+++ b/packages/vscode-container-client/src/contracts/ContainerClient.ts
@@ -630,7 +630,7 @@ export type PortBinding = {
     /**
      * The protocol the port uses
      */
-    protocol?: 'udp' | 'tcp';
+    protocol?: 'udp' | 'tcp' | 'sctp';
 };
 
 export type RunContainerBindMount = {

--- a/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
+++ b/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
@@ -41,6 +41,7 @@ const runInWsl: boolean = (process.env.RUN_IN_WSL === '1' || process.env.RUN_IN_
  */
 export const KeepAliveEntrypoint = 'tail';
 export const KeepAliveCommand = ['-f', '/dev/null'];
+const dockerPortRange = [55000, 55001, 55002];
 
 // wslc does not support the `--expose` flag on `run`, but it does support
 // network create/list/inspect/remove/prune.
@@ -395,7 +396,10 @@ describe('(integration) ContainersClientE2E', function () {
                     ],
                     ports: clientTypeToTest === 'nerdctl'
                         ? [{ hostPort: 8080, containerPort: 80 }, { hostPort: 3000, containerPort: 3000 }]
-                        : [{ hostPort: 8080, containerPort: 80 }],
+                        : clientTypeToTest === 'docker' ? [
+                            { hostPort: 8080, containerPort: 80 },
+                            ...dockerPortRange.map(port => ({ hostPort: port, containerPort: port })),
+                        ] : [{ hostPort: 8080, containerPort: 80 }],
                     // wslc has no --expose flag; rootless nerdctl cannot auto-allocate host ports
                     exposePorts: (clientTypeToTest === 'nerdctl' || !supportsExposeFlag) ? undefined : [3000],
                     publishAllPorts: clientTypeToTest === 'nerdctl' ? undefined : true, // Rootless nerdctl cannot auto-allocate host ports
@@ -465,6 +469,11 @@ describe('(integration) ContainersClientE2E', function () {
                 expect(container.ports.length).to.be.greaterThanOrEqual(0);
             } else {
                 expect(container.ports.some(p => p.hostPort === 8080 && p.containerPort === 80)).to.be.true;
+                if (clientTypeToTest === 'docker') {
+                    for (const port of dockerPortRange) {
+                        expect(container.ports.some(p => p.hostPort === port && p.containerPort === port)).to.be.true;
+                    }
+                }
                 if (supportsExposeFlag) {
                     // Exposed port with random binding - Finch uses -p <containerPort> as equivalent to --expose + --publish-all
                     // wslc has no --expose flag, so no random-binding port to validate

--- a/packages/vscode-container-client/src/test/clients/DockerClientBase/SharedListContainerRecord.test.ts
+++ b/packages/vscode-container-client/src/test/clients/DockerClientBase/SharedListContainerRecord.test.ts
@@ -86,12 +86,13 @@ describe('(unit) normalizeListContainerRecord', () => {
             ID: 'abc123',
             Names: 'azurite',
             Image: 'mcr.microsoft.com/azure-storage/azurite',
-            Ports: '0.0.0.0:10000-10002->10000-10002/tcp, [::]:10000-10002->10000-10002/tcp',
+            Ports: '80/tcp, 0.0.0.0:10000-10002->10000-10002/tcp, [::]:10000-10002->10000-10002/tcp',
         });
 
         const result = normalizeListContainerRecord(parsed, true, DockerListContainerOptions);
 
         expect(result.ports).to.deep.equal([
+            { containerPort: 80, protocol: 'tcp' },
             { hostIp: '0.0.0.0', hostPort: 10000, containerPort: 10000, protocol: 'tcp' },
             { hostIp: '0.0.0.0', hostPort: 10001, containerPort: 10001, protocol: 'tcp' },
             { hostIp: '0.0.0.0', hostPort: 10002, containerPort: 10002, protocol: 'tcp' },

--- a/packages/vscode-container-client/src/test/clients/DockerClientBase/SharedListContainerRecord.test.ts
+++ b/packages/vscode-container-client/src/test/clients/DockerClientBase/SharedListContainerRecord.test.ts
@@ -81,6 +81,26 @@ describe('(unit) normalizeListContainerRecord', () => {
         expect(result.name).to.equal('first');
     });
 
+    it('Should normalize compacted Docker port ranges in strict mode', () => {
+        const parsed = SharedListContainerRecordSchema.parse({
+            ID: 'abc123',
+            Names: 'azurite',
+            Image: 'mcr.microsoft.com/azure-storage/azurite',
+            Ports: '0.0.0.0:10000-10002->10000-10002/tcp, [::]:10000-10002->10000-10002/tcp',
+        });
+
+        const result = normalizeListContainerRecord(parsed, true, DockerListContainerOptions);
+
+        expect(result.ports).to.deep.equal([
+            { hostIp: '0.0.0.0', hostPort: 10000, containerPort: 10000, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 10001, containerPort: 10001, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 10002, containerPort: 10002, protocol: 'tcp' },
+            { hostIp: '::', hostPort: 10000, containerPort: 10000, protocol: 'tcp' },
+            { hostIp: '::', hostPort: 10001, containerPort: 10001, protocol: 'tcp' },
+            { hostIp: '::', hostPort: 10002, containerPort: 10002, protocol: 'tcp' },
+        ]);
+    });
+
     it('Should extract nerdctl networks from the nerdctl/networks label when Networks is absent', () => {
         const parsed = SharedListContainerRecordSchema.parse({
             ID: 'abc123',
@@ -122,4 +142,3 @@ describe('(unit) normalizeListContainerRecord', () => {
         expect(result.ports).to.deep.equal([]);
     });
 });
-

--- a/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
+++ b/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
@@ -4,51 +4,55 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
-import { parseDockerRawPortString, parseDockerRawPortStringList } from '../../../clients/DockerClientBase/parseDockerRawPortString';
+import { expandDockerRawPortString } from '../../../clients/DockerClientBase/parseDockerRawPortString';
 import type { PortBinding } from '../../../contracts/ContainerClient';
 
-describe('(unit) parseDockerRawPortString', () => {
-    const validCases: Array<{ input: string; expected: PortBinding }> = [
+describe('(unit) expandDockerRawPortString', () => {
+    const validCases: Array<{ input: string; expected: PortBinding[] }> = [
         {
             input: '1234/udp',
-            expected: { containerPort: 1234, protocol: 'udp' },
+            expected: [{ containerPort: 1234, protocol: 'udp' }],
+        },
+        {
+            input: '1234/sctp',
+            expected: [{ containerPort: 1234, protocol: 'sctp' }],
         },
         {
             input: '0.0.0.0:1234-> 5678/tcp',
-            expected: { hostIp: '0.0.0.0', hostPort: 1234, containerPort: 5678, protocol: 'tcp' },
+            expected: [{ hostIp: '0.0.0.0', hostPort: 1234, containerPort: 5678, protocol: 'tcp' }],
         },
         {
             input: '[1234:abcd::0]:2345-> 5678/tcp',
-            expected: { hostIp: '1234:abcd::0', hostPort: 2345, containerPort: 5678, protocol: 'tcp' },
+            expected: [{ hostIp: '1234:abcd::0', hostPort: 2345, containerPort: 5678, protocol: 'tcp' }],
         },
         {
             input: '8080->80/tcp',
-            expected: { hostPort: 8080, containerPort: 80, protocol: 'tcp' },
+            expected: [{ hostPort: 8080, containerPort: 80, protocol: 'tcp' }],
         },
         {
             input: '0.0.0.0:3000->3000',
-            expected: { hostIp: '0.0.0.0', hostPort: 3000, containerPort: 3000, protocol: 'tcp' },
+            expected: [{ hostIp: '0.0.0.0', hostPort: 3000, containerPort: 3000, protocol: 'tcp' }],
         },
         {
             // Docker's IPv6 unspecified-address wildcard form (no brackets)
             input: ':::8080->80/tcp',
-            expected: { hostIp: '::', hostPort: 8080, containerPort: 80, protocol: 'tcp' },
+            expected: [{ hostIp: '::', hostPort: 8080, containerPort: 80, protocol: 'tcp' }],
         },
         {
             // Docker's IPv6 wildcard, bracketed form
             input: '[::]:8080->80/tcp',
-            expected: { hostIp: '::', hostPort: 8080, containerPort: 80, protocol: 'tcp' },
+            expected: [{ hostIp: '::', hostPort: 8080, containerPort: 80, protocol: 'tcp' }],
         },
         {
             // Bare (unbracketed) IPv6 host with embedded colons
             input: '::1:8080->80/tcp',
-            expected: { hostIp: '::1', hostPort: 8080, containerPort: 80, protocol: 'tcp' },
+            expected: [{ hostIp: '::1', hostPort: 8080, containerPort: 80, protocol: 'tcp' }],
         },
     ];
 
     validCases.forEach(({ input, expected }) => {
         it(`Should parse "${input}"`, () => {
-            expect(parseDockerRawPortString(input)).to.deep.equal(expected);
+            expect(expandDockerRawPortString(input)).to.deep.equal(expected);
         });
     });
 
@@ -64,12 +68,12 @@ describe('(unit) parseDockerRawPortString', () => {
 
     invalidCases.forEach((input) => {
         it(`Should return undefined for invalid format "${input}"`, () => {
-            expect(parseDockerRawPortString(input)).to.be.undefined;
+            expect(expandDockerRawPortString(input)).to.be.undefined;
         });
     });
 
     it('Should expand short-form port ranges', () => {
-        expect(parseDockerRawPortStringList('10000-10002/tcp')).to.deep.equal([
+        expect(expandDockerRawPortString('10000-10002/tcp')).to.deep.equal([
             { containerPort: 10000, protocol: 'tcp' },
             { containerPort: 10001, protocol: 'tcp' },
             { containerPort: 10002, protocol: 'tcp' },
@@ -77,18 +81,45 @@ describe('(unit) parseDockerRawPortString', () => {
     });
 
     it('Should expand long-form port ranges', () => {
-        expect(parseDockerRawPortStringList('[::]:10000-10002->10000-10002/tcp')).to.deep.equal([
+        expect(expandDockerRawPortString('0.0.0.0:32768-32770->8000-8002/tcp')).to.deep.equal([
+            { hostIp: '0.0.0.0', hostPort: 32768, containerPort: 8000, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 32769, containerPort: 8001, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 32770, containerPort: 8002, protocol: 'tcp' },
+        ]);
+        expect(expandDockerRawPortString('0.0.0.0:100-102-> 100-102/tcp')).to.deep.equal([
+            { hostIp: '0.0.0.0', hostPort: 100, containerPort: 100, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 101, containerPort: 101, protocol: 'tcp' },
+            { hostIp: '0.0.0.0', hostPort: 102, containerPort: 102, protocol: 'tcp' },
+        ]);
+        expect(expandDockerRawPortString('100-101->100-101/tcp')).to.deep.equal([
+            { hostPort: 100, containerPort: 100, protocol: 'tcp' },
+            { hostPort: 101, containerPort: 101, protocol: 'tcp' },
+        ]);
+        expect(expandDockerRawPortString(':::10000-10001->10000-10001/udp')).to.deep.equal([
+            { hostIp: '::', hostPort: 10000, containerPort: 10000, protocol: 'udp' },
+            { hostIp: '::', hostPort: 10001, containerPort: 10001, protocol: 'udp' },
+        ]);
+        expect(expandDockerRawPortString('[::]:10000-10002->10000-10002/sctp')).to.deep.equal([
+            { hostIp: '::', hostPort: 10000, containerPort: 10000, protocol: 'sctp' },
+            { hostIp: '::', hostPort: 10001, containerPort: 10001, protocol: 'sctp' },
+            { hostIp: '::', hostPort: 10002, containerPort: 10002, protocol: 'sctp' },
+        ]);
+    });
+
+    it('Should expand a single-port range', () => {
+        expect(expandDockerRawPortString('10000-10000/tcp')).to.deep.equal([
+            { containerPort: 10000, protocol: 'tcp' },
+        ]);
+        expect(expandDockerRawPortString('[::]:10000-10000->10000-10000/tcp')).to.deep.equal([
             { hostIp: '::', hostPort: 10000, containerPort: 10000, protocol: 'tcp' },
-            { hostIp: '::', hostPort: 10001, containerPort: 10001, protocol: 'tcp' },
-            { hostIp: '::', hostPort: 10002, containerPort: 10002, protocol: 'tcp' },
         ]);
     });
 
     it('Should reject invalid port ranges', () => {
-        expect(parseDockerRawPortStringList('10002-10000/tcp')).to.be.undefined;
-        expect(parseDockerRawPortStringList('10000-10001->10000-10002/tcp')).to.be.undefined;
-        expect(parseDockerRawPortStringList('1-999999999999/tcp')).to.be.undefined;
-        expect(parseDockerRawPortStringList('1-999999999999->1-999999999999/tcp')).to.be.undefined;
-        expect(parseDockerRawPortStringList('65535-65536/tcp')).to.be.undefined;
+        expect(expandDockerRawPortString('10002-10000/tcp')).to.be.undefined;
+        expect(expandDockerRawPortString('10000-10001->10000-10002/tcp')).to.be.undefined;
+        expect(expandDockerRawPortString('1-999999999999/tcp')).to.be.undefined;
+        expect(expandDockerRawPortString('1-999999999999->1-999999999999/tcp')).to.be.undefined;
+        expect(expandDockerRawPortString('65535-65536/tcp')).to.be.undefined;
     });
 });

--- a/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
+++ b/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
@@ -87,5 +87,8 @@ describe('(unit) parseDockerRawPortString', () => {
     it('Should reject invalid port ranges', () => {
         expect(parseDockerRawPortStringList('10002-10000/tcp')).to.be.undefined;
         expect(parseDockerRawPortStringList('10000-10001->10000-10002/tcp')).to.be.undefined;
+        expect(parseDockerRawPortStringList('1-999999999999/tcp')).to.be.undefined;
+        expect(parseDockerRawPortStringList('1-999999999999->1-999999999999/tcp')).to.be.undefined;
+        expect(parseDockerRawPortStringList('65535-65536/tcp')).to.be.undefined;
     });
 });

--- a/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
+++ b/packages/vscode-container-client/src/test/clients/DockerClientBase/parseDockerRawPortString.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
-import { parseDockerRawPortString } from '../../../clients/DockerClientBase/parseDockerRawPortString';
+import { parseDockerRawPortString, parseDockerRawPortStringList } from '../../../clients/DockerClientBase/parseDockerRawPortString';
 import type { PortBinding } from '../../../contracts/ContainerClient';
 
 describe('(unit) parseDockerRawPortString', () => {
@@ -66,5 +66,26 @@ describe('(unit) parseDockerRawPortString', () => {
         it(`Should return undefined for invalid format "${input}"`, () => {
             expect(parseDockerRawPortString(input)).to.be.undefined;
         });
+    });
+
+    it('Should expand short-form port ranges', () => {
+        expect(parseDockerRawPortStringList('10000-10002/tcp')).to.deep.equal([
+            { containerPort: 10000, protocol: 'tcp' },
+            { containerPort: 10001, protocol: 'tcp' },
+            { containerPort: 10002, protocol: 'tcp' },
+        ]);
+    });
+
+    it('Should expand long-form port ranges', () => {
+        expect(parseDockerRawPortStringList('[::]:10000-10002->10000-10002/tcp')).to.deep.equal([
+            { hostIp: '::', hostPort: 10000, containerPort: 10000, protocol: 'tcp' },
+            { hostIp: '::', hostPort: 10001, containerPort: 10001, protocol: 'tcp' },
+            { hostIp: '::', hostPort: 10002, containerPort: 10002, protocol: 'tcp' },
+        ]);
+    });
+
+    it('Should reject invalid port ranges', () => {
+        expect(parseDockerRawPortStringList('10002-10000/tcp')).to.be.undefined;
+        expect(parseDockerRawPortStringList('10000-10001->10000-10002/tcp')).to.be.undefined;
     });
 });


### PR DESCRIPTION
## Summary

- parse consecutive port ranges emitted by `docker container ls`, including exposed and IPv4/IPv6 published ranges
- expand compacted ranges into individual port bindings during container normalization
- add regression coverage for the Azurite-style `10000-10002` range and malformed ranges

## Validation

- 239 unit tests passed
- `pnpm --filter @microsoft/vscode-container-client run lint`
- `pnpm --filter @microsoft/vscode-container-client run build`

Fixes #572