### PR TITLE
Fix issue with reserved port ranges on Windows

### DIFF
--- a/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
+++ b/packages/vscode-container-client/src/test/ContainersClientE2E.test.ts
@@ -20,7 +20,7 @@ import type { CommandResponseBase, ICommandRunnerFactory } from '../contracts/Co
 import type { IContainersClient, ListImagesItem, ListNetworkItem, ListVolumeItem } from '../contracts/ContainerClient';
 import { FileType } from '../typings/FileType';
 import { wslifyPath } from '../utils/wslifyPath';
-import { type ClientType, validateContainerExists } from './e2eShared';
+import { type ClientType, findConsecutiveFreePorts, validateContainerExists } from './e2eShared';
 
 /**
  * WARNING: This test suite will prune unused images, containers, networks, and volumes.
@@ -41,8 +41,6 @@ const runInWsl: boolean = (process.env.RUN_IN_WSL === '1' || process.env.RUN_IN_
  */
 export const KeepAliveEntrypoint = 'tail';
 export const KeepAliveCommand = ['-f', '/dev/null'];
-const dockerPortRange = [55000, 55001, 55002];
-
 // wslc does not support the `--expose` flag on `run`, but it does support
 // network create/list/inspect/remove/prune.
 const supportsExposeFlag = clientTypeToTest !== 'wslc';
@@ -330,12 +328,21 @@ describe('(integration) ContainersClientE2E', function () {
         let testContainerBindMountSource: string;
         let testContainerId: string;
 
+        // Discovered at runtime rather than hardcoded, because Windows reserves
+        // shifting blocks of ports for WinNAT/Hyper-V that cannot be bound. The
+        // ports must be consecutive so Docker reports them in compacted form.
+        let dockerPortRange: number[] = [];
+
         before('Containers', async function () {
             testContainerBindMountSource = import.meta.dirname;
 
             // If running in WSL, convert the bind mount source path to WSL format
             if (runInWsl) {
                 testContainerBindMountSource = wslifyPath(testContainerBindMountSource);
+            }
+
+            if (clientTypeToTest === 'docker') {
+                dockerPortRange = await findConsecutiveFreePorts(3);
             }
 
             // Pull a small image for testing

--- a/packages/vscode-container-client/src/test/e2eShared.ts
+++ b/packages/vscode-container-client/src/test/e2eShared.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as net from 'net';
 import type { ICommandRunnerFactory } from '../contracts/CommandRunner';
 import type { IContainersClient, ListContainersItem } from '../contracts/ContainerClient';
 
@@ -19,6 +20,58 @@ export type ClientType = 'docker' | 'podman' | 'finch' | 'nerdctl' | 'wslc';
  * after the CLI detaches.
  */
 export const KeepAliveShellCommand = "trap 'exit 0' TERM; while true; do sleep 1; done";
+
+/**
+ * Checks whether a single TCP port can be bound on the local machine.
+ *
+ * Binds to 127.0.0.1 rather than 0.0.0.0 so the probe never opens an
+ * externally-reachable listener. This still detects the cases we care about:
+ * Windows/WinNAT reserved port exclusions fail with EACCES on loopback just as
+ * they do on the wildcard address, and a port already held by a wildcard
+ * listener fails with EADDRINUSE.
+ */
+function isPortFree(port: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const server = net.createServer();
+        server.once('error', () => resolve(false));
+        server.once('listening', () => server.close(() => resolve(true)));
+        server.listen(port, '127.0.0.1');
+    });
+}
+
+/**
+ * Finds a run of `count` consecutive bindable TCP ports, starting the search at
+ * `startPort`.
+ *
+ * The ports must be consecutive so that Docker reports them in its compacted
+ * `<start>-<end>` form, which is what the port-range parsing is exercised
+ * against. Hardcoding a range is not viable: Windows reserves large, shifting
+ * blocks of ports for WinNAT/Hyper-V, so a fixed range binds fine on one machine
+ * and fails with `docker run` exit code 125 on another (or after a reboot).
+ */
+export async function findConsecutiveFreePorts(count: number, startPort: number = 56000, maxPort: number = 65000): Promise<number[]> {
+    let candidate = startPort;
+
+    while (candidate + count - 1 <= maxPort) {
+        let allFree = true;
+
+        for (let offset = 0; offset < count; offset++) {
+            if (!await isPortFree(candidate + offset)) {
+                // Skip past the port that failed; Windows exclusions come in
+                // contiguous blocks, so there is no point retrying inside one.
+                candidate = candidate + offset + 1;
+                allFree = false;
+                break;
+            }
+        }
+
+        if (allFree) {
+            return Array.from({ length: count }, (_, i) => candidate + i);
+        }
+    }
+
+    throw new Error(`Unable to find ${count} consecutive free ports between ${startPort} and ${maxPort}`);
+}
 
 function normalizeContainerNameForRuntimeComparison(name: string): string {
     // Compose implementations disagree on generated container-name separators:


### PR DESCRIPTION
WSL was reserving (but not using) some ports on Windows, causing a conflict which made the integration tests fail. Quick fix to dynamically find some free ones and use those instead.