### PR TITLE
Fix nested registry wizard silently cancelling its parent wizard

### DIFF
--- a/extensions/vscode-containers/src/utils/nestedPromptUtils.ts
+++ b/extensions/vscode-containers/src/utils/nestedPromptUtils.ts
@@ -21,13 +21,17 @@ type UserInputWithWizard = IAzureUserInput & { wizard?: unknown };
  * the outer wizard unregistered for the remainder of its steps, so the outer wizard's later prompts silently
  * lose their title, step count, back button, and cancellation checks. If there is no outer wizard, this is a
  * no-op.
+ *
+ * The callback receives whether an outer wizard is in progress. Nested wizards must not show a loading prompt
+ * of their own in that case--see {@link suppressOuterLoadingPrompt} for why--so the outer wizard's loading
+ * prompt stays visible for the duration of the nested wizard instead.
  */
-export async function preserveOuterWizard<T>(context: IActionContext, callback: () => Promise<T>): Promise<T> {
+export async function preserveOuterWizard<T>(context: IActionContext, callback: (hasOuterWizard: boolean) => Promise<T>): Promise<T> {
     const ui = context.ui as UserInputWithWizard;
     const outerWizard = ui.wizard;
 
     try {
-        return await callback();
+        return await callback(!!outerWizard);
     } finally {
         ui.wizard = outerWizard;
     }
@@ -44,7 +48,9 @@ export async function preserveOuterWizard<T>(context: IActionContext, callback: 
  * silently cancels the outer wizard. If there is no outer wizard, this is a no-op.
  *
  * Note this deliberately isn't combined with {@link preserveOuterWizard}: a nested wizard sharing this context
- * would read the same suppression flag, and would lose its own loading prompt as a result.
+ * would read the same suppression flag, and would lose its own loading prompt as a result. A nested wizard
+ * instead avoids cancelling the outer wizard by not showing a loading prompt at all, so that the outer
+ * wizard's loading prompt is never hidden while the nested wizard runs.
  */
 export async function suppressOuterLoadingPrompt<T>(context: IActionContext, callback: () => Promise<T>): Promise<T> {
     const wizardStateContext = context as WizardStateContext;

--- a/extensions/vscode-containers/src/utils/registryExperience.ts
+++ b/extensions/vscode-containers/src/utils/registryExperience.ts
@@ -46,8 +46,12 @@ export async function registryExperience<TNode extends CommonRegistryItem>(conte
         throw new UserCancelledError();
     }
 
-    const unifiedRegistryItem = await preserveOuterWizard(context, () => runQuickPickWizard<UnifiedRegistryItem<TNode>>(context, {
+    const unifiedRegistryItem = await preserveOuterWizard(context, (hasOuterWizard) => runQuickPickWizard<UnifiedRegistryItem<TNode>>(context, {
         hideStepCount: true,
+        // When running inside another wizard, this one must not show a loading prompt of its own: showing it
+        // would hide the outer wizard's, which the outer wizard treats as the user dismissing it. That leaves
+        // the outer wizard's loading prompt up while this one runs, which is what we want anyway.
+        showLoadingPrompt: !hasOuterWizard,
         promptSteps: [
             new RegistryProviderQuickPickStep(ext.registriesTree, options)
         ],


### PR DESCRIPTION
🤖 Fixes the `Build Image in Azure` / `Run Task in Azure` wizard closing silently right after the subscriptions finish loading, a regression from #547.

## What was happening

#547 converted `scheduleRunRequest` from a sequence of ad-hoc quick picks into a real `AzureWizard` with `showLoadingPrompt: true`. Its `SelectSubscriptionPromptStep` calls `subscriptionExperience()` → `registryExperience()` → `runQuickPickWizard()`, which starts a **nested** wizard that shares the outer wizard's `context.ui`, and which defaults `showLoadingPrompt` to `true`.

A wizard configured with `showLoadingPrompt` keeps a "Loading..." quick pick visible between steps, and [treats that quick pick being hidden as the user dismissing the wizard](https://github.com/microsoft/vscode-azuretools/blob/main/utils/src/wizard/AzureWizard.ts) unless its own `ui` is what's currently prompting:

```js
disposables.push(loadingQuickPick?.onDidHide(() => {
    if (!this._context.ui.isPrompting && !this._context.ui.isTesting && !this._context.suppressLoadingPrompt) {
        this._cancellationTokenSource.cancel();
    }
}));
```

So when the nested wizard showed *its* loading prompt, VS Code hid the outer wizard's, and the outer wizard cancelled its own token. On the next loop iteration the outer wizard saw `cancellationToken.isCancellationRequested` and threw `UserCancelledError` — the wizard just disappeared.

The reason this reproduces every time rather than intermittently is `skipIfOne`: `subscriptionExperience()` passes it, so with a single Azure provider and a single subscription the nested wizard resolves without ever showing a real quick pick. `ui.isPrompting` is therefore never `true`, and the cancel always goes through.

## The fix

A nested quick-pick wizard no longer shows a loading prompt of its own when it's running inside another wizard. The outer wizard's loading prompt simply stays up for the duration — which is the UX we want anyway during the slow subscription load.

`preserveOuterWizard()` already had to capture `ui.wizard` before the nested wizard clobbers it, so it now hands that information to its callback as a `hasOuterWizard` flag, and `registryExperience()` passes `showLoadingPrompt: !hasOuterWizard`.

This also removes the same hazard from **Push Image**, which nests `registryExperience()` inside its own wizard — there it was racy rather than reliable, because that call site doesn't use `skipIfOne` and so usually does prompt. `createAzureRegistry()`'s nested wizard never sets `showLoadingPrompt`, so it needed no change.

## Notes for reviewers

- Verified with `pnpm run build:check` (tsc), `pnpm run lint`, and an esbuild bundle build.
- This deliberately isn't folded into the existing `suppressOuterLoadingPrompt()` helper: that helper sets a flag on the shared context, and a nested wizard reading the same context would suppress its *own* loading prompt too. It's meant for UI shown via `executeCommand()`, which gets a separate action context.
- This can't be covered by an integration test — `AzureWizard` skips the cancel entirely when `ui.isTesting` is set, which is exactly the branch that was misbehaving.
