### PR TITLE
Fix extension README image roots

### DIFF
--- a/extensions/vscode-containers/package.json
+++ b/extensions/vscode-containers/package.json
@@ -3400,7 +3400,7 @@
         "build": "pnpm run --parallel \"/^build:(esbuild|check)$/\"",
         "build:esbuild": "node esbuild.mjs",
         "build:check": "tsc --noEmit",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-containers/",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-containers",
         "test": "vscode-test",
         "clean": "node ../../scripts/clean.mjs"
     },

--- a/extensions/vscode-containers/package.json
+++ b/extensions/vscode-containers/package.json
@@ -3400,7 +3400,7 @@
         "build": "pnpm run --parallel \"/^build:(esbuild|check)$/\"",
         "build:esbuild": "node esbuild.mjs",
         "build:check": "tsc --noEmit",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-containers",
         "test": "vscode-test",
         "clean": "node ../../scripts/clean.mjs"
     },

--- a/extensions/vscode-containers/package.json
+++ b/extensions/vscode-containers/package.json
@@ -3400,7 +3400,7 @@
         "build": "pnpm run --parallel \"/^build:(esbuild|check)$/\"",
         "build:esbuild": "node esbuild.mjs",
         "build:check": "tsc --noEmit",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-containers",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-containers/",
         "test": "vscode-test",
         "clean": "node ../../scripts/clean.mjs"
     },

--- a/extensions/vscode-docker/package.json
+++ b/extensions/vscode-docker/package.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "build": "",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-docker",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-docker/",
         "lint": "",
         "test": "",
         "clean": "node ../../scripts/clean.mjs"

--- a/extensions/vscode-docker/package.json
+++ b/extensions/vscode-docker/package.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "build": "",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-docker/",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-docker",
         "lint": "",
         "test": "",
         "clean": "node ../../scripts/clean.mjs"

--- a/extensions/vscode-docker/package.json
+++ b/extensions/vscode-docker/package.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "build": "",
-        "package": "pnpx @vscode/vsce@latest package --no-dependencies",
+        "package": "pnpx @vscode/vsce@latest package --no-dependencies --baseImagesUrl https://github.com/microsoft/vscode-containers/raw/HEAD/extensions/vscode-docker",
         "lint": "",
         "test": "",
         "clean": "node ../../scripts/clean.mjs"


### PR DESCRIPTION
🤖
## Summary
- configure VSCE to resolve Container Tools README images from the extension's relocated resource directory
- apply the corresponding image base configuration to the Docker extension package

## Validation
- packaged the Container Tools VSIX and confirmed all 10 README image URLs were rewritten to the extension resource directory
- confirmed all 10 rewritten URLs return HTTP 200
- ran `git diff --check`